### PR TITLE
Moving to partial callbacks, depreciating callback_args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,12 +24,18 @@
 - Corrected type hint for `OneCycle lr_range` to `List`
 - Corrected `on_train_end` not being called in `fold_train_ensemble`
 - Fixed crash in `plot_feat` when plotting non-bulk without cuts, and non-crash bug when plotting non-bulk with cuts
+- Fixed typing of callback_args in `fold_train_ensemble`
 
 ## Changes
 
 - Moved `on_train_end` call in `fold_train_ensemble` to after loading best set of weights
 
 ## Depreciations
+
+- Callbacks:
+    - Added `callback_partials` parameter (a list of partials that yield a Callback object) in `fold_train_ensemble` to eventually replace `callback_args`; Neater appearance than previous Dict of object and kargs
+    - `callback_args` now depreciated, to be removed in v0.3
+    - Currently `callback_args` are converted to `callback_partials, code will also be removed in v0.3
 
 ## Comments
 

--- a/lumin/optimisation/hyper_param.py
+++ b/lumin/optimisation/hyper_param.py
@@ -1,8 +1,9 @@
-from typing import Tuple, Dict, List, Optional, Any
+from typing import Tuple, Dict, List, Optional
 from fastprogress import master_bar, progress_bar
 import numpy as np
 from collections import OrderedDict
 import timeit
+from functools import partial
 
 from sklearn.ensemble.forest import ForestRegressor
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
@@ -58,7 +59,7 @@ def get_opt_rf_params(x_trn:np.ndarray, y_trn:np.ndarray, x_val:np.ndarray, y_va
 
 def fold_lr_find(fy:FoldYielder, model_builder:ModelBuilder, bs:int,
                  train_on_weights:bool=True, shuffle_fold:bool=True, n_folds:int=-1, lr_bounds:Tuple[float,float]=[1e-5, 10],
-                 callback_args:Dict[str,Dict[str,Any]]={}, plot_settings:PlotSettings=PlotSettings()) -> List[LRFinder]:
+                 callback_partials:List[partial]=[], plot_settings:PlotSettings=PlotSettings()) -> List[LRFinder]:
     '''Wrapper function for running Smith LR range tests (https://arxiv.org/abs/1803.09820) using folds in FoldYielder'''
     tmr = timeit.default_timer()
     idxs = range(fy.n_folds) if n_folds < 1 else range(min(n_folds, fy.n_folds))
@@ -69,13 +70,12 @@ def fold_lr_find(fy:FoldYielder, model_builder:ModelBuilder, bs:int,
         nb = len(trn_fold['targets'])//bs
         lr_finder = LRFinder(nb=nb, lr_bounds=lr_bounds, model=model)
         cyclic_callback,callbacks = None,[]
-        for c in callback_args: callbacks.append(c['callback'](**c['kargs']))
+        for c in callback_partials: callbacks.append(c(model=model))
         for c in callbacks:
             if isinstance(c, AbsCyclicCallback): c.set_nb(nb)
         for c in callbacks:
             if isinstance(c, AbsModelCallback): c.set_cyclic_callback(cyclic_callback)
         for c in callbacks:
-            c.set_model(model)
             c.on_train_begin()
         lr_finder.on_train_begin()
         batch_yielder = BatchYielder(**fy.get_fold(trn_id), objective=model_builder.objective, bs=bs, use_weights=train_on_weights, shuffle=shuffle_fold)


### PR DESCRIPTION
## Fixes

- Corrected type hint for `OneCycle lr_range` to `List`

## Depreciations

- Callbacks:
    - Added `callback_partials` parameter (a list of partials that yield a Callback object) in `fold_train_ensemble` to eventually replace `callback_args`; Neater appearance than previous Dict of object and kargs
    - `callback_args` now depreciated, to be removed in v0.3
    - Currently `callback_args` are converted to `callback_partials, code will also be removed in v0.3