### PR TITLE
Res fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,12 @@
 
 ## Breaking
 
-- Changed callbacks to receive `kargs`, rather than logs to allow for great flexibility.
+- Changed callbacks to receive `kargs`, rather than logs to allow for great flexibility
+- Residual mode in `FullyConnected`:
+    - Identity paths now skip two layers instead of one to align better with [arXiv:1603.05027](https://arxiv.org/abs/1603.05027)
+    - In cases where an odd number of layers are specified for the body, the number of lkayers is increased by one
+    - Batch normalisation now corrected to be after the addition step (previously was set before)
+- Dense mode in `FullyConnected` now no longer adds an extra layer to scale down to the original width, instead `get_out_size` now returns the width of the final concatinated layer and the tail of the network is expected to accept this input size
 
 ## Additions
 
@@ -28,6 +33,7 @@
 - Fixed crash in `plot_feat` when plotting non-bulk without cuts, and non-crash bug when plotting non-bulk with cuts
 - Fixed typing of callback_args in `fold_train_ensemble`
 - Fixed crash when trying to load model trained on cuda device for application on CPU device
+- Fixed positioning of batch normalisation in residual mode of `FullyConnected` to after addition
 
 ## Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Changed callbacks to receive `kargs`, rather than logs to allow for great flexibility
 - Residual mode in `FullyConnected`:
     - Identity paths now skip two layers instead of one to align better with [arXiv:1603.05027](https://arxiv.org/abs/1603.05027)
-    - In cases where an odd number of layers are specified for the body, the number of lkayers is increased by one
+    - In cases where an odd number of layers are specified for the body, the number of layers is increased by one
     - Batch normalisation now corrected to be after the addition step (previously was set before)
 - Dense mode in `FullyConnected` now no longer adds an extra layer to scale down to the original width, instead `get_out_size` now returns the width of the final concatinated layer and the tail of the network is expected to accept this input size
 

--- a/lumin/nn/models/blocks/body.py
+++ b/lumin/nn/models/blocks/body.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable
+import numpy as np
 
 import torch.nn as nn
 import torch
@@ -7,6 +8,52 @@ from torch import Tensor
 from ..layers.activations import lookup_act
 from ..initialisations import lookup_normal_init
 
+
+class AbsBody(nn.Module):
+    def __init__(self, depth:int, width:int, do:float, bn:bool, act:str,
+                 lookup_init:Callable[[str,Optional[int],Optional[int]],Callable[[Tensor],None]]=lookup_normal_init,
+                 lookup_act:Callable[[str],nn.Module]=lookup_act, freeze:bool=False):
+        super().__init__()
+        self.depth,self.width,self.do,self.bn,self.act = depth,width,do,bn,act
+
+    def __getitem__(self, key:int) -> nn.Module: return self.layers[key]
+
+    def freeze_layers(self):
+        for p in self.parameters(): p.requires_grad = False
+    
+    def unfreeze_layers(self):
+        for p in self.parameters(): p.requires_grad = True
+
+    def get_out_size(self) -> int: return self.width    
+
+
+# class FullyConnected(AbsBody):
+#     '''Fully connected set of hidden layers'''
+#     def __init__(self, depth:int, width:int, do:float, bn:bool, act:str,
+#                  lookup_init:Callable[[str,Optional[int],Optional[int]],Callable[[Tensor],None]]=lookup_normal_init,
+#                  lookup_act:Callable[[str],nn.Module]=lookup_act, freeze:bool=False):
+#         super().__init__(depth=depth, width=width, do=do, bn=bn, act=act, lookup_init=lookup_init, lookup_act=lookup_act, freeze=freeze)
+#         self.layers = nn.ModuleList([self.get_layer(d) for d in range(depth)])
+#         if self.freeze: self.freeze_layers
+    
+#     def get_layer(self, idx:int, fan_in:Optional[int]=None, fan_out:Optional[int]=None) -> nn.Sequential:
+#         width = self.width if not self.dense else self.width*(2**idx)
+#         fan_in  = width if fan_in  is None else fan_in
+#         fan_out = width if fan_out is None else fan_out
+        
+#         layers = [nn.Linear(fan_in, fan_out)]
+#         self.lookup_init(self.act, fan_in, fan_out)(layers[-1].weight)
+#         if self.act != 'linear': layers.append(self.lookup_act(self.act))
+#         if self.bn: layers.append(nn.BatchNorm1d(fan_out))
+#         if self.do: 
+#             if self.act == 'selu': layers.append(nn.AlphaDropout(self.do))
+#             else:                  layers.append(nn.Dropout(self.do))
+#         return nn.Sequential(*layers)
+    
+#     def forward(self, x:Tensor) -> Tensor:
+#         for l in self.layers: x = l(x)
+#         return x
+    
 
 class FullyConnected(nn.Module):
     '''Fully connected set of hidden layers.
@@ -19,8 +66,11 @@ class FullyConnected(nn.Module):
         self.depth,self.width,self.do,self.bn,self.act,self.res,self.dense = depth,width,do,bn,act,res,dense,
         self.lookup_init,self.lookup_act,self.freeze = lookup_init,lookup_act,freeze
 
-        self.layers = nn.ModuleList([self.get_layer(d) for d in range(depth)])
-        if dense: self.layers += [self.get_layer(depth, self.width*(2**(self.depth)), self.width)]
+        if self.res:
+            self.depth = int(np.ceil(self.depth/2))  # Each block will contain 2 layers
+            self.res_bns = nn.ModuleList([nn.BatchNorm1d(self.width) for d in range(self.depth)])
+        self.layers = nn.ModuleList([self.get_layer(d) for d in range(self.depth)])
+        #if dense: self.layers += [self.get_layer(depth, self.width*(2**(self.depth)), self.width)]
         if self.freeze: self.freeze_layers
 
     def __getitem__(self, key:int) -> nn.Module: return self.layers[key]
@@ -36,13 +86,15 @@ class FullyConnected(nn.Module):
         fan_in  = width if fan_in  is None else fan_in
         fan_out = width if fan_out is None else fan_out
         
-        layers = [nn.Linear(fan_in, fan_out)]
-        self.lookup_init(self.act, fan_in, fan_out)(layers[-1].weight)
-        if self.act != 'linear': layers.append(self.lookup_act(self.act))
-        if self.bn or self.res:  layers.append(nn.BatchNorm1d(fan_out))
-        if self.do: 
-            if self.act == 'selu': layers.append(nn.AlphaDropout(self.do))
-            else:                  layers.append(nn.Dropout(self.do))
+        layers = []
+        for i in range(2 if self.res else 1):
+            layers.append(nn.Linear(fan_in, fan_out))
+            self.lookup_init(self.act, fan_in, fan_out)(layers[-1].weight)
+            if self.act != 'linear': layers.append(self.lookup_act(self.act))
+            if self.bn and i == 0:  layers.append(nn.BatchNorm1d(fan_out))  # In case of residual, BN will be added after addition
+            if self.do: 
+                if self.act == 'selu': layers.append(nn.AlphaDropout(self.do))
+                else:                  layers.append(nn.Dropout(self.do))
         return nn.Sequential(*layers)
     
     def forward(self, x:Tensor) -> Tensor:
@@ -50,7 +102,12 @@ class FullyConnected(nn.Module):
             for l in self.layers[:-1]: x = torch.cat((l(x), x), 1)
             x = self.layers[-1](x)
         else:
-            for l in self.layers: x = l(x)+x if self.res else l(x)
+            for i, l in enumerate(self.layers):
+                if self.res:
+                    x = l(x)+x
+                    x = self.res_bns[i](x)  # Renormalise after addition
+                else:
+                    x = l(x)
         return x
     
-    def get_out_size(self) -> int: return self.width
+    def get_out_size(self) -> int: return self.width if not self.dense else self.width*(2**(self.depth-1))


### PR DESCRIPTION
## Breaking

- Residual mode in `FullyConnected`:
    - Identity paths now skip two layers instead of one to align better with [arXiv:1603.05027](https://arxiv.org/abs/1603.05027)
    - In cases where an odd number of layers are specified for the body, the number of layers is increased by one
    - Batch normalisation now corrected to be after the addition step (previously was set before)
- Dense mode in `FullyConnected` now no longer adds an extra layer to scale down to the original width, instead `get_out_size` now returns the width of the final concatinated layer and the tail of the network is expected to accept this input size

## Additions

## Removals

## Fixes

- Fixed positioning of batch normalisation in residual mode of `FullyConnected` to after addition

## Changes

## Depreciations