### PR TITLE
 Simplifying embedding settings by replacing args with helper class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Master - targeting V0.2
 
+## Important changes
+- Residual mode in `FullyConnected`:
+    - Identity paths now skip two layers instead of one to align better with [arXiv:1603.05027](https://arxiv.org/abs/1603.05027)
+    - In cases where an odd number of layers are specified for the body, the number of layers is increased by one
+    - Batch normalisation now corrected to be after the addition step (previously was set before)
+- Dense mode in `FullyConnected` now no longer adds an extra layer to scale down to the original width, instead `get_out_size` now returns the width of the final concatinated layer and the tail of the network is expected to accept this input size
+- Fixed rule-of-thumb for embedding sizes from max(50, 1+(sz//2)) to max(50, (1+sz)//2)
+
+
 ## Breaking
 
 - Changed callbacks to receive `kargs`, rather than logs to allow for great flexibility
@@ -39,6 +48,7 @@
 - `rf_rank_features` was accidentally evaluating feature importance on validation data rather than training data, resulting in lower importances that it should
 - Fixed feature selection in examples using a test size of 0.8 rather than 0.2
 - Fixed crash when no importnat features were found by `rf_rank_features`
+- Fixed rule-of-thumb for embedding sizes from max(50, 1+(sz//2)) to max(50, (1+sz)//2)
 
 ## Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,6 @@
 - Dense mode in `FullyConnected` now no longer adds an extra layer to scale down to the original width, instead `get_out_size` now returns the width of the final concatinated layer and the tail of the network is expected to accept this input size
 - Fixed rule-of-thumb for embedding sizes from max(50, 1+(sz//2)) to max(50, (1+sz)//2)
 
-
 ## Breaking
 
 - Changed callbacks to receive `kargs`, rather than logs to allow for great flexibility

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
     - In cases where an odd number of layers are specified for the body, the number of layers is increased by one
     - Batch normalisation now corrected to be after the addition step (previously was set before)
 - Dense mode in `FullyConnected` now no longer adds an extra layer to scale down to the original width, instead `get_out_size` now returns the width of the final concatinated layer and the tail of the network is expected to accept this input size
+- Initialisation arguments for `CatEmbHead` changed considerably w.r.t. embedding arguments; now expects to receive a `Embedder` class
 
 ## Additions
 
@@ -22,6 +23,7 @@
 - Added option to turn of realtime loss plots
 - Added `from_results` and `from_save` classmethods for `Ensemble`
 - Added option to `SWA` to control whether it only updates on cycle end when paired with an `AbsCyclicalCallback`
+- Added helper class `Embedder` to simplify parsing of embedding settings
 
 ## Removals
 
@@ -47,7 +49,11 @@
 - Callbacks:
     - Added `callback_partials` parameter (a list of partials that yield a Callback object) in `fold_train_ensemble` to eventually replace `callback_args`; Neater appearance than previous Dict of object and kargs
     - `callback_args` now depreciated, to be removed in v0.3
-    - Currently `callback_args` are converted to `callback_partials, code will also be removed in v0.3
+    - Currently `callback_args` are converted to `callback_partials`, code will also be removed in v0.3
+- Embeddings:
+    - Added `cat_embedder` parameter to `ModelBuilder` to eventuall replace `cat_args`
+    - `cat_args` now depreciated to be removed in v0.3
+    - Currently `cat_args` are converted to an `Embedder`, code will also be removed in v0.3
 
 ## Comments
 

--- a/lumin/nn/models/helpers.py
+++ b/lumin/nn/models/helpers.py
@@ -1,0 +1,44 @@
+from typing import List, Tuple, Optional, Union
+from pathlib import Path
+import numpy as np
+
+from ..data.fold_yielder import FoldYielder
+
+
+class Embedder():
+    def __init__(self, cat_names:List[str], cat_szs:List[int],
+                 emb_szs:Optional[List[int]]=None, max_emb_sz:int=50, emb_load_path:Optional[Union[Path,str]]=None):
+        assert len(cat_names) == len(cat_szs), "Different number of feature names and feature cardinalities received"
+        if emb_szs is not None: assert len(cat_szs) == len(emb_szs), "Different number of features and embedding sizes received"
+        self.cat_names,self.cat_szs,self.emb_szs,self.max_emb_sz,self.emb_load_path = cat_names,cat_szs,emb_szs,max_emb_sz,emb_load_path
+        if self.emb_szs is None: self.calc_emb_szs()
+        if self.emb_load_path is not None and not isinstance(self.emb_load_path, Path): self.emb_load_path = Path(self.emb_load_path)
+        self.n_cat_in = len(self.cat_szs)
+        
+    def __repr__(self) -> str:
+        rep = ""
+        for i in range(self.n_cat_in): rep += f'{self.cat_names[i]}:\t{self.cat_szs[i]} --> {self.emb_szs[i]}\n'
+        if self.emb_load_path is not None: rep += f'\nLoading pretrained embeddings from: {self.emb_load_path}'
+        return rep
+    
+    def __getitem__(self, key:Union[int,str]) -> Tuple[int,int]:
+        if isinstance(key, int): return (self.cat_szs[key], self.emb_szs[key])
+        else:                    return self[self.cat_names.index(key)]
+    
+    def __iter__(self) -> Tuple[int,int]:
+        for name, sz, emb_sz in zip(self.cat_names, self.cat_szs, self.emb_szs): yield name, sz, emb_sz
+            
+    @classmethod
+    def from_fy(cls, fy:FoldYielder,  emb_szs:Optional[List[int]]=None, max_emb_sz:int=50, emb_load_path:Optional[Union[Path,str]]=None):
+        cat_names = fy.cat_feats
+        cat_szs = None
+        # Get cardinalities
+        for fld_id in range(len(fy)):
+            tmp_max = fy.get_df(pred_name=None, targ_name=None, wgt_name=None, n_folds=1, fold_idx=0, inc_inputs=True,
+                                verbose=False, suppress_warn=True)[cat_names].max().values.astype(int)
+            if cat_szs is None: cat_szs = tmp_max
+            else:               cat_szs = np.maximum(cat_szs, tmp_max)
+        cat_szs = list(1+cat_szs)  # zero-ordered, therefore cardinality is 1+max
+        return cls(cat_names=cat_names, cat_szs=cat_szs, emb_szs=emb_szs, max_emb_sz=max_emb_sz, emb_load_path=emb_load_path)
+            
+    def calc_emb_szs(self) -> None: self.emb_szs = [min(self.max_emb_sz, (1+sz)//2) for sz in self.cat_szs]

--- a/lumin/nn/models/model_builder.py
+++ b/lumin/nn/models/model_builder.py
@@ -1,8 +1,9 @@
 
 import numpy as np
-from typing import Dict, Union, Any, Callable, Tuple, Optional
+from typing import Dict, Union, Any, Callable, Tuple, Optional, List
 from pathlib import Path
 import pickle
+import  warnings
 
 import torch.nn as nn
 import torch.optim as optim
@@ -11,6 +12,7 @@ import torch
 
 from .layers.activations import lookup_act
 from .initialisations import lookup_normal_init
+from .helpers import Embedder
 from .blocks.body import FullyConnected
 from .blocks.head import CatEmbHead
 from .blocks.tail import ClassRegMulti
@@ -25,16 +27,24 @@ Todo
 class ModelBuilder(object):
     '''Class to build models to specified architecture on demand along with an optimiser'''
     def __init__(self, objective:str, n_cont_in:int, n_out:int, y_range:Optional[Union[Tuple,np.ndarray]]=None,
-                 model_args:Dict[str,Any]={}, opt_args:Dict[str,Any]={}, cat_args:Dict[str,Any]=None,
+                 model_args:Dict[str,Any]={}, opt_args:Dict[str,Any]={}, cat_embedder:Optional[Embedder]=None,
                  loss:Union[Any,'auto']='auto', head:nn.Module=CatEmbHead, body:nn.Module=FullyConnected, tail:nn.Module=ClassRegMulti,
                  lookup_init:Callable[[str,Optional[int],Optional[int]],Callable[[Tensor],None]]=lookup_normal_init,
-                 lookup_act:Callable[[str],nn.Module]=lookup_act, pretrain_file:Optional[str]=None, freeze_head:bool=False, freeze_body:bool=False):
-        self.objective,self.n_cont_in,self.n_out,self.y_range,self.head,self.body,self.tail  = objective.lower(),n_cont_in,n_out,y_range,head,body,tail
+                 lookup_act:Callable[[str],nn.Module]=lookup_act, pretrain_file:Optional[str]=None, freeze_head:bool=False, freeze_body:bool=False,
+                 cat_args:Dict[str,Any]=None):
+        self.objective,self.n_cont_in,self.n_out,self.y_range,self.cat_embedder = objective.lower(),n_cont_in,n_out,y_range,cat_embedder
+        self.head,self.body,self.tail = head,body,tail
         self.lookup_init,self.lookup_act,self.pretrain_file,self.freeze_head,self.freeze_body = lookup_init,lookup_act,pretrain_file,freeze_head,freeze_body
         self.parse_loss(loss)
         self.parse_model_args(model_args)
         self.parse_opt_args(opt_args)
-        self.parse_cat_args(cat_args)
+        # XXX Remove in v0.3
+        if self.cat_embedder is None and  cat_args is not None:
+            warnings.warn('''Passing cat_args (dictionary of lists for embedding categorical features) is depreciated and will be removed in v0.3.
+                             Please move to passing an Embedder class to cat_embedder''')
+            cat_args = {k:cat_args[k] for k in cat_args if k != 'n_cat_in'}
+            if 'emb_szs' in cat_args: cat_args['emb_szs'] = cat_args['emb_szs'][:,-1]
+            self.cat_embedder = Embedder(**cat_args)
 
     @classmethod
     def from_model_builder(cls, model_builder, pretrain_file:Optional[str]=None, freeze_head:bool=False, freeze_body:bool=False,
@@ -50,18 +60,6 @@ class ModelBuilder(object):
                    cat_args=cat_args, model_args=model_args, opt_args=opt_args if opt_args is not None else {},
                    loss=model_builder.loss if loss is None else loss, head=model_builder.head, body=model_builder.body, tail=model_builder.tail,
                    pretrain_file=pretrain_file, freeze_head=freeze_head, freeze_body=freeze_body)
-
-    def parse_cat_args(self, cat_args) -> None:
-        cat_args = {k.lower(): cat_args[k] for k in cat_args}
-        self.n_cat_in      = 0    if 'n_cat_in'      not in cat_args else cat_args['n_cat_in']
-        self.cat_szs       = None if 'cat_szs'       not in cat_args else cat_args['cat_szs']
-        self.emb_szs       = None if 'emb_szs'       not in cat_args else cat_args['emb_szs']
-        self.cat_names     = None if 'cat_names'     not in cat_args else cat_args['cat_names']
-        self.emb_load_path = None if 'emb_load_path' not in cat_args else cat_args['emb_load_path']
-        
-        if self.cat_szs is None: self.n_cat_in = 0; return  # Treat cats as conts
-        if self.emb_szs is None: self.emb_szs = np.array([(sz, min(50, 1+(sz//2))) for sz in self.cat_szs])
-        if isinstance(self.emb_load_path, str): self.emb_load_path = Path(self.emb_load_path)
             
     def parse_loss(self, loss:Union[Any,'auto']='auto') -> None:
         if loss == 'auto':
@@ -98,9 +96,8 @@ class ModelBuilder(object):
     def set_lr(self, lr:float) -> None: self.opt_args['lr'] = lr
 
     def get_head(self) -> nn.Module:
-        return self.head(n_cont_in=self.n_cont_in, n_cat_in=self.n_cat_in, cat_names=self.cat_names, n_out=self.width, act=self.act,
-                         emb_szs=self.emb_szs, emb_load_path=self.emb_load_path, do=self.do, do_cont=self.do_cont, do_cat=self.do_cat, bn=self.bn,
-                         lookup_init=self.lookup_init, lookup_act=self.lookup_act, freeze=self.freeze_head)
+        return self.head(n_cont_in=self.n_cont_in, n_out=self.width, act=self.act, do=self.do, do_cont=self.do_cont, do_cat=self.do_cat, bn=self.bn,
+                         cat_embedder=self.cat_embedder, lookup_init=self.lookup_init, lookup_act=self.lookup_act, freeze=self.freeze_head)
 
     def get_body(self, depth:int) -> nn.Module:
         return self.body(depth=depth, width=self.width, do=self.do, bn=self.bn, act=self.act, res=self.res, dense=self.dense,

--- a/lumin/nn/training/fold_train.py
+++ b/lumin/nn/training/fold_train.py
@@ -52,9 +52,10 @@ def fold_train_ensemble(fy:FoldYielder, n_models:int, bs:int, model_builder:Mode
         log_file = open(savepath/'training_log.log', 'w')
         sys.stdout = log_file
 
+    # XXX remove in v0.3
     if len(callback_partials) == 0 and len(callback_args) > 0:
         warnings.warn('''Passing callback_args (list of dictionaries containing callback and kargs) is depreciated and will be removed in v0.3.
-                         Please move to passing callback_partials (list of partials yielding callbacks''', FutureWarning)
+                         Please move to passing callback_partials (list of partials yielding callbacks''')
         for c in callback_args: callback_partials.append(partial(c['callback'], **c['kargs']))
 
     train_tmr = timeit.default_timer()


### PR DESCRIPTION
## Important changes
- Fixed rule-of-thumb for embedding sizes from max(50, 1+(sz//2)) to max(50, (1+sz)//2)

## Breaking

- Initialisation arguments for `CatEmbHead` changed considerably w.r.t. embedding arguments; now expects to receive a `Embedder` class

## Additions

- Added helper class `Embedder` to simplify parsing of embedding settings

## Removals

## Fixes

- Fixed rule-of-thumb for embedding sizes from max(50, 1+(sz//2)) to max(50, (1+sz)//2)

## Changes


## Depreciations

- Embeddings:
    - Added `cat_embedder` parameter to `ModelBuilder` to eventuall replace `cat_args`
    - `cat_args` now depreciated to be removed in v0.3
    - Currently `cat_args` are converted to an `Embedder`, code will also be removed in v0.3