### PR TITLE
subsample refactor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - Added string interpretation check when loading `ModelBuilder` saved in pre-v0.3.1 versions
 - `rf_rank_features` importance cut now >= threshold, was previously >
 - `plot_rank_order_dendrogram` now clusters by absolute Spearman's rank correlation coeficient
+- `feat_map` to `self.feat_map` in `MultiBlock.__init__`
 
 ## Changes
 
@@ -42,8 +43,14 @@
 - Moved to Pandas 0.25.0
 - Moved to Seaborn 0.9.0
 - Moved to Scikit-learn 0.21.0
+- `model_builder.get_model` now returns a 4th object, an input_mask
+- Feature subsampling:
+    - Moved to `ModelBuilder` rather than `FeatureSubsample` callback: required to handle `MultiBlock` models
+    - Now allows a list of features to always be present in model via `ModelBuilder.guaranteed_feats`
 
 ## Depreciations
+
+- `FeatureSubsample` in favour of `guaranteed_feats` and `cont_subsample_rate` in `ModelBuilder`. Will be removed in v0.5.
 
 ## Comments
 

--- a/lumin/nn/callbacks/data_callbacks.py
+++ b/lumin/nn/callbacks/data_callbacks.py
@@ -195,7 +195,12 @@ class FeatureSubsample(Callback):
     r'''
     Callback for training a model on a random sub-sample of the range of possible input features.
     Only sub-samples continuous features. Number of continuous inputs infered from model.
-    Associated :class:`~lumin.nn.models.model.Model` will automatically mask its inputs during inference; simply provide inputs with the same number of columns as trainig data. 
+    Associated :class:`~lumin.nn.models.model.Model` will automatically mask its inputs during inference; simply provide inputs with the same number of columns
+    as trainig data. 
+
+    .. Attention:: This callback is now deprecieated in favour of passing `cont_subsample_rate` and  `guaranteed_feats` to
+        :class:`~lumin.nn.models.model_builder.ModelBuilder` as these offer greater functionality and are compatable with using a
+        :class:`~luminnn.models.blocks.body.MultiBlock` body. Will be removed in `V0.5`.
 
     Arguments:
         cont_feats: list of all continuous features in input data. Order must match.
@@ -204,8 +209,6 @@ class FeatureSubsample(Callback):
     Examples::
         >>> feat_subsample = FeatureSubsample(cont_feats=['pT', 'eta', 'phi'])
     '''
-
-    # TODO cont feat names no longer required only number; move to infer number of cont feats from model_builder and batch_yielder
 
     def __init__(self, cont_feats:List[str], model:Optional[AbsModel]=None):
         super().__init__(model=model)
@@ -224,13 +227,3 @@ class FeatureSubsample(Callback):
         np.random.seed()  # Is this necessary?
         self._sample_feats()
         self.model.set_input_mask(self.feat_idxs)
-        
-    def on_epoch_begin(self, by:BatchYielder, **kargs) -> None:
-        r'''
-        Masks input data to remove non-selected features
-
-        Arguments:
-            by: BatchYielder providing data for the upcoming epoch
-        '''
-        
-        by.inputs = by.inputs[:,self.feat_idxs]

--- a/lumin/nn/callbacks/data_callbacks.py
+++ b/lumin/nn/callbacks/data_callbacks.py
@@ -198,9 +198,11 @@ class FeatureSubsample(Callback):
     Associated :class:`~lumin.nn.models.model.Model` will automatically mask its inputs during inference; simply provide inputs with the same number of columns
     as trainig data. 
 
-    .. Attention:: This callback is now deprecieated in favour of passing `cont_subsample_rate` and  `guaranteed_feats` to
+    .. Attention:: This callback is now depreciated in favour of passing `cont_subsample_rate` and  `guaranteed_feats` to
         :class:`~lumin.nn.models.model_builder.ModelBuilder` as these offer greater functionality and are compatable with using a
         :class:`~luminnn.models.blocks.body.MultiBlock` body. Will be removed in `V0.5`.
+
+    .. Caution:: This callback is incompatable with using a :class:`~luminnn.models.blocks.body.MultiBlock` body
 
     Arguments:
         cont_feats: list of all continuous features in input data. Order must match.

--- a/lumin/nn/models/blocks/body.py
+++ b/lumin/nn/models/blocks/body.py
@@ -204,14 +204,14 @@ class MultiBlock(AbsBody):
         
         if self.bottleneck_sz > 0:
             self.bottleneck_blocks,self.bottleneck_masks = [],[]
-            for i, fs in enumerate(self.feats_per_block):
-                tmp_map = {f: feat_map[f] for f in feat_map if f not in feats_per_block[i]}
+            for fpb in self.feats_per_block:
+                tmp_map = {f: self.feat_map[f] for f in self.feat_map if f not in fpb}
                 self.bottleneck_masks.append([i for f in tmp_map for i in tmp_map[f]])
                 self.bottleneck_blocks.append(self._get_bottleneck(self.bottleneck_masks[-1]))
             self.bottleneck_blocks = nn.ModuleList(self.bottleneck_blocks)
 
         for i, b in enumerate(blocks):
-            tmp_map = {f: feat_map[f] for f in feat_map if f in feats_per_block[i]}
+            tmp_map = {f: self.feat_map[f] for f in self.feat_map if f in self.feats_per_block[i]}
             self.masks.append([i for f in tmp_map for i in tmp_map[f]])
             self.blocks.append(b(n_in=len(self.masks[-1])+self.bottleneck_sz, feat_map=tmp_map, lookup_init=self.lookup_init,
                                  lookup_act=self.lookup_act, freeze=self.freeze))
@@ -221,7 +221,7 @@ class MultiBlock(AbsBody):
     def _get_bottleneck(self, mask:List[int]) -> nn.Module:
         layers = [nn.Linear(len(mask), self.bottleneck_sz)]
         if self.bottleneck_act is None:
-            init = self.lookup_init('linear', len(mask), self.bottleneck_sz) 
+            init = self.lookup_init('linear', len(mask), self.bottleneck_sz)
         else:
             init = self.lookup_init(self.bottleneck_act, len(mask), self.bottleneck_sz)
             layers.append(self.lookup_act(self.bottleneck_act))

--- a/lumin/nn/models/model_builder.py
+++ b/lumin/nn/models/model_builder.py
@@ -1,7 +1,9 @@
 
 from typing import Dict, Union, Any, Callable, Tuple, Optional, List, Iterator
 import pickle
-import  warnings
+import warnings
+import math
+import numpy as np
 
 import torch.nn as nn
 import torch.optim as optim
@@ -40,6 +42,8 @@ class ModelBuilder(object):
         opt_args: dictionary of arguments to pass to optimiser. Missing kargs will be filled with default values.
             Currently, only ADAM (default), RAdam, Ranger, and SGD are available.
         cat_embedder: :class:`~lumin.nn.models.helpers.CatEmbedder` for embedding categorical inputs
+        cont_subsample_rate: if between in range (0, 1), will randomly select a fraction of continuous features (rounded upwards) to use as inputs
+        guaranteed_feats: if subsampling features, will always include the features listed here, which count towards the subsample fraction
         loss: either and uninstantiated loss class, or leave as 'auto' to select loss according to objective
         head: uninstantiated class which can receive input data and upscale it to model width
         body: uninstantiated class which implements the main bulk of the model's hidden layers
@@ -98,12 +102,14 @@ class ModelBuilder(object):
 
     def __init__(self, objective:str, n_out:int, cont_feats:Optional[List[str]]=None,
                  model_args:Optional[Dict[str,Dict[str,Any]]]=None, opt_args:Optional[Dict[str,Any]]=None, cat_embedder:Optional[CatEmbedder]=None,
+                 cont_subsample_rate:Optional[float]=None, guaranteed_feats:Optional[List[str]]=None,
                  loss:Any='auto', head:AbsHead=CatEmbHead, body:AbsBody=FullyConnected, tail:AbsTail=ClassRegMulti,
                  lookup_init:Callable[[str,Optional[int],Optional[int]],Callable[[Tensor],None]]=lookup_normal_init,
                  lookup_act:Callable[[str],nn.Module]=lookup_act, pretrain_file:Optional[str]=None,
                  freeze_head:bool=False, freeze_body:bool=False, freeze_tail:bool=False,
                  cat_args:Dict[str,Any]=None, n_cont_in:Optional[int]=None):
         self.objective,self.cont_feats,self.n_out,self.cat_embedder = objective.lower(),cont_feats,n_out,cat_embedder
+        self.cont_subsample_rate,self.guaranteed_feats = cont_subsample_rate,guaranteed_feats
         self.head,self.body,self.tail = head,body,tail
         self.lookup_init,self.lookup_act,self.pretrain_file, = lookup_init,lookup_act,pretrain_file
         self.freeze_head,self.freeze_body,self.freeze_tail = freeze_head,freeze_body,freeze_tail
@@ -116,7 +122,7 @@ class ModelBuilder(object):
                              Please move to passing a list of names of continuous input features to cont_feats.
                              This is necessary for using certain classes, e.g. MultiBlock body.''')
             self.cont_feats = [str(i) for i in range(n_cont_in)]
-        self.n_cont_in = len(self.cont_feats)
+        self._subsample()
         # XXX Remove in v0.4
         if self.cat_embedder is None and  cat_args is not None:
             warnings.warn('''Passing cat_args (dictionary of lists for embedding categorical features) is depreciated and will be removed in v0.4.
@@ -169,8 +175,10 @@ class ModelBuilder(object):
         if isinstance(model_builder, str):
             with open(model_builder, 'rb') as fin: model_builder = pickle.load(fin)
         model_args = {'head': model_builder.head_kargs, 'body': model_builder.body_kargs, 'tail': model_builder.tail_kargs}
+        if not hasattr(model_builder, 'cont_subsample_rate'): model_builder.cont_subsample_rate,model_builder.guaranteed_feats = None,None  # <0.3.2 compat
         return cls(objective=model_builder.objective, cont_feats=model_builder.cont_feats, n_out=model_builder.n_out,
                    cat_embedder=model_builder.cat_embedder, model_args=model_args, opt_args=opt_args if opt_args is not None else {},
+                   cont_subsample_rate=model_builder.cont_subsample_rate, guaranteed_feats=model_builder.guaranteed_feats,
                    loss=model_builder.loss if loss is None else loss, head=model_builder.head, body=model_builder.body, tail=model_builder.tail,
                    pretrain_file=pretrain_file, freeze_head=freeze_head, freeze_body=freeze_body, freeze_tail=freeze_tail)
             
@@ -201,6 +209,23 @@ class ModelBuilder(object):
         else:
             self.opt = opt_args['opt'] if not isinstance(opt_args['opt'], str) else self._interp_opt(opt_args['opt'])
 
+    def _subsample(self) -> None:
+        if self.cont_subsample_rate is not None:
+            self.use_conts = self.guaranteed_feats if self.guaranteed_feats is not None else []
+            n = math.ceil(len(self.cont_feats)*self.cont_subsample_rate)-len(self.use_conts)
+            np.random.seed()  # Is this necessary?
+            self.use_conts += list(np.random.choice([f for f in self.cont_feats if f not in self.use_conts], size=n, replace=False))
+            self.n_cont_in = len(self.use_conts)
+            cont_idxs = np.array([self.cont_feats.index(f) for f in self.use_conts])
+            cat_idxs  = len(self.cont_feats)+np.arange(self.cat_embedder.n_cat_in)
+            self.input_mask = np.hstack((cont_idxs, cat_idxs))
+            self.input_mask.sort()
+            
+        else:
+            self.use_conts = self.cont_feats
+            self.n_cont_in = len(self.cont_feats)
+            self.input_mask = None
+
     @staticmethod
     def _interp_opt(opt:str) -> Callable[[Iterator, Optional[Any]], optim.Optimizer]:
         opt = opt.lower()
@@ -230,7 +255,7 @@ class ModelBuilder(object):
             Instantiated head nn.Module
         '''
 
-        return self.head(cont_feats=self.cont_feats, cat_embedder=self.cat_embedder, lookup_init=self.lookup_init, freeze=self.freeze_head, **self.head_kargs)
+        return self.head(cont_feats=self.use_conts, cat_embedder=self.cat_embedder, lookup_init=self.lookup_init, freeze=self.freeze_head, **self.head_kargs)
 
     def get_body(self, n_in:int, feat_map:List[str]) -> AbsBody:
         r'''
@@ -292,7 +317,7 @@ class ModelBuilder(object):
         if self.pretrain_file is not None: self.load_pretrained(model)
         model = to_device(model)
         opt = self._build_opt(model)
-        return model, opt, self.loss
+        return model, opt, self.loss, self.input_mask
 
     def get_out_size(self) -> int:
         r'''


### PR DESCRIPTION
# Targeting V0.3.2

## Important changes

## Breaking

## Additions

## Removals

## Fixes
- `feat_map` to `self.feat_map` in `MultiBlock.__init__`

## Changes

- `model_builder.get_model` now returns a 4th object, an input_mask
- Feature subsampling:
    - Moved to `ModelBuilder` rather than `FeatureSubsample` callback: required to handle `MultiBlock` models
    - Now allows a list of features to always be present in model via `ModelBuilder.guaranteed_feats`

## Depreciations

- `FeatureSubsample` in favour of `guaranteed_feats` and `cont_subsample_rate` in `ModelBuilder`. Will be removed in v0.5.

## Comments