### PR TITLE
Fold meta

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,11 @@
 - `__repr__` of `Model` now detail information about input variables
 - `MultiHead` to allow the use of multiple head blocks to handle input data containing flat and matrix inputs
 - `AbsMatrixHead` abstract class for head blocks designed to process matrix data
--  `InteractionNet` a new head block to apply interaction graph-nets to objects in matrix form
+- `InteractionNet` a new head block to apply interaction graph-nets to objects in matrix form
+- Meta data:
+    - `FoldYielder` now checks its foldfile for a `meta_data` group which contains information about the features and inputs in the data
+    - `cont_feats` and `cat_feats` now no longer need to be passed to `FoldYielder` during initialisation of the foldfile contains meta data
+    - `add_meta_data` function added to write meta data to foldfiles and is automatically called by `df2foldfile` 
 
 ## Removals
 
@@ -22,6 +26,7 @@
 ## Changes
 
 - Slight optimisation in `FullyConnected` when not using dense or residual networks 
+- `FoldYielder.set_foldfile` is now a private function `FoldYielder._set_foldfile`
 
 ## Depreciations
 

--- a/lumin/data_processing/file_proc.py
+++ b/lumin/data_processing/file_proc.py
@@ -1,13 +1,14 @@
 import h5py
 import numpy as np
 import pandas as pd
-from typing import List, Union, Optional, Any
+from typing import List, Union, Optional, Any, Tuple, Dict
 import os
 from pathlib import Path
+import json
 
 from sklearn.model_selection import StratifiedKFold, KFold
 
-__all__ = ['save_to_grp', 'fold2foldfile', 'df2foldfile']
+__all__ = ['save_to_grp', 'fold2foldfile', 'df2foldfile', 'add_meta_data']
 
 
 def save_to_grp(arr:np.ndarray, grp:h5py.Group, name:str) -> None:
@@ -22,14 +23,38 @@ def save_to_grp(arr:np.ndarray, grp:h5py.Group, name:str) -> None:
 
     # TODO Option for string length
 
-    ds = grp.create_dataset(name, shape=arr.shape, dtype=arr.dtype.name if arr.dtype.name != 'object' else 'S16')
-    ds[...] = arr if arr.dtype.name != 'object' else arr.astype('S16')
+    ds = grp.create_dataset(name, shape=arr.shape, dtype=arr.dtype.name if arr.dtype.name not in ['object', 'str864'] else 'S64')
+    ds[...] = arr if arr.dtype.name not in ['object', 'str864'] else arr.astype('S64')
+
+
+def _build_matrix_lookups(feats:List[str], vecs:List[str], feats_per_vec:List[str], row_wise:bool) -> Tuple[List[str],np.ndarray,Tuple[int,int]]:
+    shape = (len(vecs),len(feats_per_vec)) if row_wise else (len(feats_per_vec),len(vecs))
+    lookup,missing = np.zeros(shape, dtype=np.array(feats).dtype),np.zeros(shape, dtype=np.bool)
+    if row_wise:
+        for i, v in enumerate(vecs):
+            for j, c in enumerate(feats_per_vec):
+                f = f'{v}_{c}'
+                if f in feats:
+                    lookup[i,j] = f
+                else:
+                    lookup[i,j] = feats[0]  # Temp value, to be set to null later using missing
+                    missing[i,j] = True
+    else:
+        for j, v in enumerate(vecs):
+            for i, c in enumerate(feats_per_vec):
+                f = f'{v}_{c}'
+                if f in feats:
+                    lookup[i,j] = f
+                else:
+                    lookup[i,j] = feats[0]  # Temp value, to be set to null later using missing
+                    missing[i,j] = True
+    return list(lookup.flatten()),missing.flatten(),shape
 
 
 def fold2foldfile(df:pd.DataFrame, out_file:h5py.File, fold_idx:int,
                   cont_feats:List[str], cat_feats:List[str], targ_feats:Union[str,List[str]], targ_type:Any,
                   misc_feats:Optional[List[str]]=None, wgt_feat:Optional[str]=None,
-                  matrix_feats:Optional[Union[List[List[str]],np.ndarray]]=None) -> None:
+                  matrix_lookup:Optional[List[str]]=None, matrix_missing:Optional[np.ndarray]=None, matrix_shape:Optional[Tuple[int,int]]=None) -> None:
     r'''
     Save fold of data into an h5py Group
 
@@ -43,7 +68,11 @@ def fold2foldfile(df:pd.DataFrame, out_file:h5py.File, fold_idx:int,
         targ_type: type of target feature, e.g. int,'float32'
         misc_feats: any extra columns to save
         wgt_feat: column to save as data weights
-        matrix_feats: 2-D Array of feature values to store as a matrix in relevant positions. Features listed but not present in df will be replaced with NaN.
+        matrix_vecs: list of objects for matrix encoding, i.e. feature prefixes 
+        matrix_feats_per_vec: list of features per vector for matrix encoding, i.e. feature suffixes.
+            Features listed but not present in df will be replaced with NaN.
+        matrix_row_wise: whether objects encoded as a matrix should be encoded row-wise (i.e. all the features associated with an object are in their own row),
+            or column-wise (i.e. all the features associated with an object are in their own column)
     '''
 
     # TODO infer target type automatically
@@ -55,25 +84,17 @@ def fold2foldfile(df:pd.DataFrame, out_file:h5py.File, fold_idx:int,
     if misc_feats is not None:
         for f in misc_feats: save_to_grp(df[f].values, grp, f)
 
-    if matrix_feats is not None:
-        if isinstance(matrix_feats, list): matrix_feats = np.array(matrix_feats)
-        x = df[matrix_feats.flatten()].values
-        mat = np.zeros((len(df),len(matrix_feats),len(matrix_feats[0])))
-        k = 0 
-        for i in range(len(matrix_feats)):
-            for j,f in enumerate(matrix_feats[i]):
-                if f in df.columns:
-                    mat[:,i,j] = x[:,k]
-                    k += 1
-                else:
-                    mat[:,i,j] = np.NaN
+    if matrix_lookup is not None:
+        mat = df[matrix_lookup].values
+        mat[:,matrix_missing] = np.NaN
+        mat = mat.reshape((len(df),*matrix_shape))
         save_to_grp(mat, grp, 'matrix_inputs')
 
 
 def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:List[str],
                 targ_feats:Union[str,List[str]], savename:Union[Path,str], targ_type:str,
-                strat_key:Optional[str]=None, misc_feats:Optional[List[str]]=None, wgt_feat:Optional[str]=None,
-                matrix_feats:Optional[Union[List[List[str]],np.ndarray]]=None) -> None:
+                strat_key:Optional[str]=None, misc_feats:Optional[List[str]]=None, wgt_feat:Optional[str]=None, cat_maps:Optional[Dict[str,Dict[int,Any]]]=None,
+                matrix_vecs:Optional[List[str]]=None, matrix_feats_per_vec:Optional[List[str]]=None, matrix_row_wise:Optional[bool]=None) -> None:
     r'''
     Convert dataframe into h5py file by splitting data into sub-folds to be accessed by a :class:`~lumin.nn.data.fold_yielder.FoldYielder`
     
@@ -82,19 +103,32 @@ def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:Li
         n_folds: number of folds to split df into
         cont_feats: list of columns in df to save as continuous variables
         cat_feats: list of columns in df to save as discreet variables
-        targ_feats (list of) column(s) in df to save as target feature(s)
+        targ_feats: (list of) column(s) in df to save as target feature(s)
         savename: name of h5py file to create (.h5py extension not required)
         targ_type: type of target feature, e.g. int,'float32'
-        strat_key (optional): column to use for stratified splitting
-        misc_feats (optional): any extra columns to save
-        wgt_feat (optional): column to save as data weights
-        matrix_feats: 2-D Array of feature values to store as a matrix in relevant positions. Features listed but not present in df will be replaced with NaN.
+        strat_key: column to use for stratified splitting
+        misc_feats: any extra columns to save
+        wgt_feat: column to save as data weights
+        cat_maps: Dictionary mapping categorical features to dictionary mapping codes to categories
+        matrix_vecs: list of objects for matrix encoding, i.e. feature prefixes 
+        matrix_feats_per_vec: list of features per vector for matrix encoding, i.e. feature suffixes.
+            Features listed but not present in df will be replaced with NaN.
+        matrix_row_wise: whether objects encoded as a matrix should be encoded row-wise (i.e. all the features associated with an object are in their own row),
+            or column-wise (i.e. all the features associated with an object are in their own column)
     '''
 
     savename = str(savename)
     os.system(f'rm {savename}.hdf5')
     os.makedirs(savename[:savename.rfind('/')], exist_ok=True)
     out_file = h5py.File(f'{savename}.hdf5', "w")
+    lookup,missing,shape = None,None,None
+    if matrix_vecs is not None:
+        lookup,missing,shape = _build_matrix_lookups(df.columns, matrix_vecs, matrix_feats_per_vec, matrix_row_wise)
+        mat_feats = list(np.array(lookup)[np.logical_not(missing)])  # Only features present in data
+        dup = [f for f in cont_feats if f in mat_feats]
+        if len(dup) > 1:
+            print(f'{dup} present in both matrix features and continuous features; removing from continuous features')
+            for f in dup: cont_feats.remove(f)
 
     if strat_key is None:
         kf = KFold(n_splits=n_folds, shuffle=True)
@@ -105,5 +139,43 @@ def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:Li
     for fold_idx, (_, fold) in enumerate(folds):
         print(f"Saving fold {fold_idx} with {len(fold)} events")
         fold2foldfile(df.iloc[fold].copy(), out_file, fold_idx, cont_feats=cont_feats, cat_feats=cat_feats, targ_feats=targ_feats,
-                      targ_type=targ_type, misc_feats=misc_feats, wgt_feat=wgt_feat, matrix_feats=matrix_feats)
-                      
+                      targ_type=targ_type, misc_feats=misc_feats, wgt_feat=wgt_feat,
+                      matrix_lookup=lookup, matrix_missing=missing, matrix_shape=shape)
+    add_meta_data(out_file=out_file, feats=df.columns, cont_feats=cont_feats, cat_feats=cat_feats, cat_maps=cat_maps, targ_feats=targ_feats, wgt_feat=wgt_feat,
+                  matrix_vecs=matrix_vecs, matrix_feats_per_vec=matrix_feats_per_vec, matrix_row_wise=matrix_row_wise)
+
+
+def add_meta_data(out_file:h5py.File, feats:List[str], cont_feats:List[str], cat_feats:List[str], cat_maps:Optional[Dict[str,Dict[int,Any]]],
+                  targ_feats:Union[str,List[str]], wgt_feat:Optional[str]=None,
+                  matrix_vecs:Optional[List[str]]=None, matrix_feats_per_vec:Optional[List[str]]=None, matrix_row_wise:Optional[bool]=None) -> None:
+    r'''
+    Adds meta data to foldfile containing information about the data: feature names, matrix information, etc.
+    :class:`~lumin.nn.data.fold_yielder.FoldYielder` objects will access this and automatically extract it to save the user from having to manually pass lists
+    of features.
+
+    Arguments:
+        out_file: h5py file to save data in
+        feats: list of all features in data
+        cont_feats: list of continuous features
+        cat_feats: list of categorical features
+        cat_maps: Dictionary mapping categorical features to dictionary mapping codes to categories
+        targ_feats: (list of) target feature(s)
+        wgt_feat: name of weight feature
+        matrix_vecs: list of objects for matrix encoding, i.e. feature prefixes 
+        matrix_feats_per_vec: list of features per vector for matrix encoding, i.e. feature suffixes.
+            Features listed but not present in df will be replaced with NaN.
+        matrix_row_wise: whether objects encoded as a matrix should be encoded row-wise (i.e. all the features associated with an object are in their own row),
+            or column-wise (i.e. all the features associated with an object are in their own column)
+    '''
+
+    grp = out_file.create_group('meta_data')
+    grp.create_dataset('cont_feats',   data=json.dumps(cont_feats))
+    grp.create_dataset('cat_feats',    data=json.dumps(cat_feats))
+    grp.create_dataset('targ_feats',   data=json.dumps(targ_feats))
+    if wgt_feat is not None: grp.create_dataset('wgt_feat', data=json.dumps(wgt_feat))
+    if cat_maps is not None: grp.create_dataset('cat_maps', data=json.dumps(cat_maps))
+    if matrix_vecs is not None:
+        lookup,missing,shape = _build_matrix_lookups(feats, matrix_vecs, matrix_feats_per_vec, matrix_row_wise)
+        use = list(np.array(lookup)[np.logical_not(missing)])  # Only features present in data
+        grp.create_dataset('matrix_feats', data=json.dumps({'present_feats': use, 'vecs': matrix_vecs, 'missing': [int(m) for m in missing],
+                                                            'feats_per_vec': matrix_feats_per_vec, 'row_wise': matrix_row_wise, 'shape': shape}))

--- a/lumin/nn/data/fold_yielder.py
+++ b/lumin/nn/data/fold_yielder.py
@@ -104,7 +104,7 @@ class FoldYielder:
         '''
         
         if not isinstance(foldfile,  h5py.File): foldfile = h5py.File(foldfile, "r+")
-        self.foldfile, self.n_folds = foldfile, len(foldfile)
+        self.foldfile, self.n_folds = foldfile, len([f for f in foldfile if 'fold_' in f])
         self.has_matrix = 'matrix_inputs' in self.columns()
         if 'meta_data' in self.foldfile: self._load_meta_data()
 

--- a/lumin/nn/interpretation/features.py
+++ b/lumin/nn/interpretation/features.py
@@ -4,7 +4,6 @@ import pandas as pd
 import sklearn.utils
 from typing import Optional
 
-from ...utils.misc import to_tensor
 from ...utils.statistics import bootstrap_stats
 from ...utils.multiprocessing import mp_run
 from ...plotting.interpretation import plot_importance
@@ -13,8 +12,6 @@ from ..ensemble.abs_ensemble import AbsEnsemble
 from ..data.fold_yielder import FoldYielder
 from ..metrics.eval_metric import EvalMetric
 from ...plotting.plot_settings import PlotSettings
-
-from torch import Tensor
 
 __all__ = ['get_nn_feat_importance', 'get_ensemble_feat_importance']
 

--- a/lumin/nn/models/blocks/head.py
+++ b/lumin/nn/models/blocks/head.py
@@ -60,9 +60,7 @@ class AbsMatrixHead(AbsHead):
         '''
 
         shp = (self.n_v,self.n_fpv) if self.row_wise else (self.n_fpv,self.n_v)
-        lookup = torch.zeros(shp, dtype=torch.long)
-        missing = torch.zeros(shp, dtype=torch.uint8)
-        
+        lookup,missing = torch.zeros(shp, dtype=torch.long),torch.zeros(shp, dtype=torch.uint8)
         if self.row_wise:
             for i, v in enumerate(self.vecs):
                 for j, c in enumerate(self.fpv):

--- a/lumin/optimisation/hyper_param.py
+++ b/lumin/optimisation/hyper_param.py
@@ -4,7 +4,6 @@ import numpy as np
 from collections import OrderedDict
 import timeit
 from functools import partial
-import math
 
 from sklearn.ensemble.forest import ForestRegressor
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier


### PR DESCRIPTION
# Targeting V0.4.1

## Important changes

## Breaking

## Additions

- Meta data:
    - `FoldYielder` now checks its foldfile for a `meta_data` group which contains information about the features and inputs in the data
    - `cont_feats` and `cat_feats` now no longer need to be passed to `FoldYielder` during initialisation of the foldfile contains meta data
    - `add_meta_data` function added to write meta data to foldfiles and is automatically called by `df2foldfile` 

## Removals

## Fixes

## Changes
- `FoldYielder.set_foldfile` is now a private function `FoldYielder._set_foldfile`

## Depreciations

## Comments