### PR TITLE
correction to cycle patience

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - `auto_filter_on_linear_correlation` now examines **all** features within correlated clusters, rather than just the most correlated pair. This means that the function now only needs to be run once, rather than the previously recommended multiple rerunning.
 - Moved to Scikit-learn 0.23.1, and moved, where possible, to keyword argument calls for sklearn methods in preparation for 0.25 enforcement of keyword arguments
+- Fixed error in patience when using cyclical LR callbacks, now specify the number of cycles to go without improvement. Previously had to specify 1+number.
 
 ## Breaking
 
@@ -35,6 +36,7 @@
 - Fixed bug in `fold_lr_find` where LR finders would use different LR steps leading to NaNs when plotting in `fold_lr_find`
 - `plot_feat` used to coerce NaNs and Infs via `np.nan_to_num` prior to plotting, potentially impacting distributions, plotting scales, moments, etc. Fixed so that nan and inf values are removed rather than coerced.
 - Fixed early-stopping statement in `fold_train_ensemble` to state the number as "sub-epochs" (previously said "epochs")
+- Fixed error in patience when using cyclical LR callbacks, now specify the number of cycles to go without improvement. Previously had to specify 1+number.
 
 ## Changes
 

--- a/examples/Binary_Classification.ipynb
+++ b/examples/Binary_Classification.ipynb
@@ -1640,7 +1640,7 @@
     "from functools import partial\n",
     "\n",
     "n_models = 3\n",
-    "patience = 2\n",
+    "patience = 1  # One entire LR cycle without improvement\n",
     "max_epochs = 33\n",
     "\n",
     "callback_partials = [partial(CycleLR, lr_range=(0, 6e-3), cycle_mult=2)]\n",

--- a/lumin/nn/training/fold_train.py
+++ b/lumin/nn/training/fold_train.py
@@ -150,6 +150,7 @@ def fold_train_ensemble(fy:FoldYielder, n_models:int, bs:int, model_builder:Mode
             if isinstance(c, AbsCyclicCallback):
                 c.set_nb(nb)
                 cyclic_callback = c
+                improv_in_cycle = False
         for c in callbacks:
             if isinstance(c, AbsModelCallback):
                 c.set_val_fold(val_fold)
@@ -210,8 +211,14 @@ def fold_train_ensemble(fy:FoldYielder, n_models:int, bs:int, model_builder:Mode
                     epoch_counter = 0
                     if loss_callback_idx is not None: loss_callbacks[loss_callback_idx].test_model.save(savepath/"best.h5")
                     else: model.save(savepath/"best.h5")
+                    if cyclic_callback is not None: improv_in_cycle = True
                 elif cyclic_callback is not None:
-                    if cyclic_callback.cycle_end: epoch_counter += 1
+                    if cyclic_callback.cycle_end:
+                        if improv_in_cycle:
+                            epoch_counter = 0
+                            improv_in_cycle = False
+                        else:
+                            epoch_counter += 1
                 else:
                     epoch_counter += 1
 


### PR DESCRIPTION
Closes issue #37 
# Targeting V0.5.2

## Important changes

- Fixed error in patience when using cyclical LR callbacks, now specify the number of cycles to go without improvement. Previously had to specify 1+number.

## Breaking

## Additions

## Removals

## Fixes

- Fixed error in patience when using cyclical LR callbacks, now specify the number of cycles to go without improvement. Previously had to specify 1+number.

## Changes

## Depreciations

## Comments