### PR TITLE
Test path correction in example notebook

### DIFF
--- a/examples/Classification_of_earnings.ipynb
+++ b/examples/Classification_of_earnings.ipynb
@@ -280,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_test = pd.read_csv('data/adult_test.csv', header=None, skiprows=[0])"
+    "df_test = pd.read_csv(PATH/'adult_test.csv', header=None, skiprows=[0])"
    ]
   },
   {


### PR DESCRIPTION
In the [notebook](https://github.com/GilesStrong/lumin/blob/master/examples/Classification_of_earnings.ipynb), the test path needs to be more generic in case the example data is downloaded to a different path.