### PR TITLE
Highio mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@
 - Error in `MultiHead._set_feats` when `matrix_head` does not contain 'vecs' or 'feats_per_vec' keywords
 - Compatibility error in numpy >= 1.18 in `bin_binary_class_pred` due to float instead of int
 - Unnecessary second loading of fold data in `fold_lr_find`
+- Compatibility error when working in PyTorch 1.6 based on integer and true division
 
 ## Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
   - `df2foldfile`, `fold2foldfile`, and 'add_meta_data` can now support the saving of arbitrary matrices as a matrix input
   - Pass a `numpy.array` whose first dimension matches the length of the DataFrame to the `tensor_data` argument of `df2foldfile` and a name to `tensor_name`.
     The array will be split along the first dimension and the sub-arrays will be saved as matrix inputs in the resulting foldfile
+  - The matrices may also be passed as sparse format and be densified on loading by FoldYielder
 - `plot_lr_finders` now has a `log_y` argument for logarithmic y-axis. Default `auto` set log_y if maximum fractional difference between losses is greater than 50
 - Added new rescaling options to `ClassRegMulti` using linear outputs and scaling by mean and std of targets
 - `LsuvInit` now applies scaling to `nn.Conv3d` layers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `auto_filter_on_linear_correlation` now examines **all** features within correlated clusters, rather than just the most correlated pair. This means that the function now only needs to be run once, rather than the previously recommended multiple rerunning.
 - Moved to Scikit-learn 0.22.2, and moved, where possible, to keyword argument calls for sklearn methods in preparation for 0.25 enforcement of keyword arguments
 - Fixed error in patience when using cyclical LR callbacks, now specify the number of cycles to go without improvement. Previously had to specify 1+number.
+- Matrix data is no longer passed through `np.nan_to_num` in `FoldYielder`. Users should ensure that all values in matrix data are not NaN or Inf
 
 ## Breaking
 
@@ -76,6 +77,7 @@
 - `auto_filter_on_linear_correlation` now examines **all** features within correlated clusters, rather than just the most correlated pair. This means that the function now only needs to be run once, rather than the previously recommended multiple rerunning.
 - Improved data shuffling in `BatchYielder`, now runs much quicker
 - Slight speedup when loading data from foldfiles
+- Matrix data is no longer passed through `np.nan_to_num` in `FoldYielder`. Users should ensure that all values in matrix data are not NaN or Inf
 
 ## Depreciations
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
 - Doc links in `hep_proc`
 - Error in `MultiHead._set_feats` when `matrix_head` does not contain 'vecs' or 'feats_per_vec' keywords
 - Compatibility error in numpy >= 1.18 in `bin_binary_class_pred` due to float instead of int
+- Unnecessary second loading of fold data in `fold_lr_find`
 
 ## Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 - `plot_lr_finders` and `fold_lr_find` now have options to save the resulting LR finder plot (currently limited to png due to problems with pdf)
 - Addition of AdamW and an optimiser, thanks to [@kiryteo](https://github.com/kiryteo)
 - Contribution guide, thanks to [@kiryteo](https://github.com/kiryteo)
+- OneCycle `lr_range` now supports a non-zero final LR; just supply a three-tuple to the `lr_range` argument.
 
 ## Removals
 

--- a/examples/RNNs_CNNs_and_GNNs_for_matrix_data.ipynb
+++ b/examples/RNNs_CNNs_and_GNNs_for_matrix_data.ipynb
@@ -3645,7 +3645,8 @@
     "    print('Fitting preproc pipe')\n",
     "    input_pipe = fit_input_pipe(df, ['jet_pT'], PATH/'input_pipe')\n",
     "    print('Transforming features')\n",
-    "    df[['jet_pT']] = input_pipe.transform(df[['jet_pT']])  # Rescale and shift track momenta values"
+    "    df[['jet_pT']] = input_pipe.transform(df[['jet_pT']])  # Rescale and shift track momenta values\n",
+    "    df[train_feats] = df[train_feats].replace(np.nan, 0.0) # Matrix dat amust not contain NaNs"
    ]
   },
   {

--- a/lumin/data_processing/file_proc.py
+++ b/lumin/data_processing/file_proc.py
@@ -177,7 +177,7 @@ def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:Li
 def add_meta_data(out_file:h5py.File, feats:List[str], cont_feats:List[str], cat_feats:List[str], cat_maps:Optional[Dict[str,Dict[int,Any]]],
                   targ_feats:Union[str,List[str]], wgt_feat:Optional[str]=None,
                   matrix_vecs:Optional[List[str]]=None, matrix_feats_per_vec:Optional[List[str]]=None, matrix_row_wise:Optional[bool]=None,
-                  tensor_name:Optional[str]=None, tensor_shp:Optional[Tuple[int]]=None) -> None:
+                  tensor_name:Optional[str]=None, tensor_shp:Optional[Tuple[int]]=None, tensor_is_sparse:bool=False) -> None:
     r'''
     Adds meta data to foldfile containing information about the data: feature names, matrix information, etc.
     :class:`~lumin.nn.data.fold_yielder.FoldYielder` objects will access this and automatically extract it to save the user from having to manually pass lists
@@ -196,6 +196,9 @@ def add_meta_data(out_file:h5py.File, feats:List[str], cont_feats:List[str], cat
             Features listed but not present in df will be replaced with NaN.
         matrix_row_wise: whether objects encoded as a matrix should be encoded row-wise (i.e. all the features associated with an object are in their own row),
             or column-wise (i.e. all the features associated with an object are in their own column)
+        tensor_name: Name used to refer to the tensor when displaying model information
+        tensor_shp: The shape of the tensor data (exclusing batch dimension)
+        tensor_is_sparse: Whether the tensor is sparse (COO format) and should be densified prior to use
     '''
 
     grp = out_file.create_group('meta_data')
@@ -211,4 +214,4 @@ def add_meta_data(out_file:h5py.File, feats:List[str], cont_feats:List[str], cat
                                                             'feats_per_vec': matrix_feats_per_vec, 'row_wise': matrix_row_wise, 'shape': shape}))
     elif tensor_name is not None:
         grp.create_dataset('matrix_feats', data=json.dumps({'present_feats': [tensor_name], 'vecs': [tensor_name], 'missing': [],
-                                                            'feats_per_vec': [''], 'row_wise': None, 'shape': tensor_shp}))
+                                                            'feats_per_vec': [''], 'row_wise': None, 'shape': tensor_shp, 'is_sparse':tensor_is_sparse}))

--- a/lumin/data_processing/file_proc.py
+++ b/lumin/data_processing/file_proc.py
@@ -111,7 +111,7 @@ def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:Li
                 targ_feats:Union[str,List[str]], savename:Union[Path,str], targ_type:str,
                 strat_key:Optional[str]=None, misc_feats:Optional[List[str]]=None, wgt_feat:Optional[str]=None, cat_maps:Optional[Dict[str,Dict[int,Any]]]=None,
                 matrix_vecs:Optional[List[str]]=None, matrix_feats_per_vec:Optional[List[str]]=None, matrix_row_wise:Optional[bool]=None,
-                tensor_data:Optional[np.ndarray]=None, tensor_name:Optional[str]=None, compression:Optional[str]=None) -> None:
+                tensor_data:Optional[np.ndarray]=None, tensor_name:Optional[str]=None, tensor_is_sparse:bool=False, compression:Optional[str]=None) -> None:
     r'''
     Convert dataframe into h5py file by splitting data into sub-folds to be accessed by a :class:`~lumin.nn.data.fold_yielder.FoldYielder`
     
@@ -136,6 +136,8 @@ def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:Li
             The array will be saved under matrix data, and this is incompatible with also setting `matrix_vecs`, `matrix_feats_per_vec`, and `matrix_row_wise`.
             The first dimension of the array must be compatible with the length of the data frame.
         tensor_name: if `tensor_data` is set, then this is the name that will to the foldfile's metadata.
+        tensor_is_sparse: Set to True if the matrix is in sparse COO format and should be densified later on
+            The format expected is `coo_x = sparse.as_coo(x); m = np.vstack((coo_x.data, coo_x.coords))`, where `m` is the tensor passed to `tensor_data`.
         compression: optional compression argument for h5py, e.g. 'lzf'
     '''
 
@@ -171,7 +173,7 @@ def df2foldfile(df:pd.DataFrame, n_folds:int, cont_feats:List[str], cat_feats:Li
                       compression=compression)
     add_meta_data(out_file=out_file, feats=df.columns, cont_feats=cont_feats, cat_feats=cat_feats, cat_maps=cat_maps, targ_feats=targ_feats, wgt_feat=wgt_feat,
                   matrix_vecs=matrix_vecs, matrix_feats_per_vec=matrix_feats_per_vec, matrix_row_wise=matrix_row_wise,
-                  tensor_name=tensor_name, tensor_shp=tensor_data[0].shape if tensor_data is not None else None)
+                  tensor_name=tensor_name, tensor_shp=tensor_data[0].shape if tensor_data is not None else None, tensor_is_sparse=tensor_is_sparse)
 
 
 def add_meta_data(out_file:h5py.File, feats:List[str], cont_feats:List[str], cat_feats:List[str], cat_maps:Optional[Dict[str,Dict[int,Any]]],

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -239,7 +239,7 @@ class OneCycle(AbsCyclicCallback):
             self.cycle_count += 0.5
             self.cycle_end = self.cycle_count % 1 == 0
             self.lr_range[0] = self.lr_range[2]
-        if self.cycle_count == 1: self.model.stop_train = True
+        if self.cycle_count == 1: self.model.stop_train = True; self.plot()
 
     def plot(self):
         r'''

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -239,7 +239,7 @@ class OneCycle(AbsCyclicCallback):
             self.cycle_count += 0.5
             self.cycle_end = self.cycle_count % 1 == 0
             self.lr_range[0] = self.lr_range[2]
-        if self.cycle_count == 1: self.model.stop_train = True; self.plot()
+        if self.cycle_count == 1: self.model.stop_train = True
 
     def plot(self):
         r'''
@@ -256,5 +256,4 @@ class OneCycle(AbsCyclicCallback):
             for ax in axs:
                 ax.tick_params(axis='x', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
                 ax.tick_params(axis='y', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
-            axs[0].set_yscale('log', nonposy='clip')
             plt.show()

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -256,5 +256,5 @@ class OneCycle(AbsCyclicCallback):
             for ax in axs:
                 ax.tick_params(axis='x', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
                 ax.tick_params(axis='y', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
-            ax[0].set_yscale('log', nonposy='clip')
+            axs[0].set_yscale('log', nonposy='clip')
             plt.show()

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -256,4 +256,5 @@ class OneCycle(AbsCyclicCallback):
             for ax in axs:
                 ax.tick_params(axis='x', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
                 ax.tick_params(axis='y', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
+            ax[0].set_yscale('log', nonposy='clip')
             plt.show()

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -196,7 +196,7 @@ class OneCycle(AbsCyclicCallback):
 
     Arguments:
         lengths: tuple of number of (sub-)epochs in first and second stages of cycle
-        lr_range: tuple of initial and final LRs
+        lr_range: list of initial and max LRs and optionally a final LR. If only two LRs supplied, then final LR will be zero.
         mom_range: tuple of initial and final momenta
         interp: 'cosine' or 'linear' interpolation
         model: :class:`~lumin.nn.models.model.Model` to alter, alternatively call :meth:`~lumin.nn.models.Model.set_model`
@@ -212,6 +212,7 @@ class OneCycle(AbsCyclicCallback):
                  model:Optional[AbsModel]=None, nb:Optional[int]=None, plot_settings:PlotSettings=PlotSettings()):
         super().__init__(interp=interp, param_range=None, cycle_mult=1, scale=lengths[0], model=model, nb=nb, plot_settings=plot_settings)
         self.lengths,self.lr_range,self.mom_range,self.hist = lengths,lr_range,mom_range,{'lr': [], 'mom': []}
+        if len(self.lr_range) == 2: self.lr_range.append(0)
 
     def on_batch_begin(self, **kargs) -> None:
         r'''
@@ -237,8 +238,8 @@ class OneCycle(AbsCyclicCallback):
             self.nb = self.lengths[1]*self.nb/self.lengths[0]
             self.cycle_count += 0.5
             self.cycle_end = self.cycle_count % 1 == 0
-            self.lr_range[0] = 0
-        if self.cycle_count == 1: self.model.stop_train = True
+            self.lr_range[0] = self.lr_range[2]
+        if self.cycle_count == 1: self.model.stop_train = True; self.plot()
 
     def plot(self):
         r'''

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -239,7 +239,7 @@ class OneCycle(AbsCyclicCallback):
             self.cycle_count += 0.5
             self.cycle_end = self.cycle_count % 1 == 0
             self.lr_range[0] = self.lr_range[2]
-        if self.cycle_count == 1: self.model.stop_train = True; self.plot()
+        if self.cycle_count == 1: self.model.stop_train = True
 
     def plot(self):
         r'''

--- a/lumin/nn/callbacks/model_callbacks.py
+++ b/lumin/nn/callbacks/model_callbacks.py
@@ -140,14 +140,14 @@ class SWA(AbsModelCallback):
         for param in self.weights:
             self.weights[param] *= self.swa_n
             self.weights[param] += c_weights[param]
-            self.weights[param] = torch.true_div(self.weights[param], self.swa_n+1)
+            torch.true_divide_(self.weights[param], self.swa_n+1)
         
         if self.swa_n > self.renewal_period and self.first_completed and self.renewal_period > 0:
             if self.verbose: print(f"New model is {self.n_since_renewal} epochs old")
             for param in self.weights_new:
                 self.weights_new[param] *= self.n_since_renewal
                 self.weights_new[param] += c_weights[param]
-                self.weights_new[param] = torch.true_div(self.weights_new[param], self.n_since_renewal+1)
+                torch.true_divide_(self.weights_new[param], self.n_since_renewal+1)
             
     def _compare_averages(self) -> None:
         if self.loss is None:

--- a/lumin/nn/callbacks/model_callbacks.py
+++ b/lumin/nn/callbacks/model_callbacks.py
@@ -140,14 +140,14 @@ class SWA(AbsModelCallback):
         for param in self.weights:
             self.weights[param] *= self.swa_n
             self.weights[param] += c_weights[param]
-            torch.true_div_(self.weights[param], self.swa_n+1)
+            self.weights[param] = torch.true_div(self.weights[param], self.swa_n+1)
         
         if self.swa_n > self.renewal_period and self.first_completed and self.renewal_period > 0:
             if self.verbose: print(f"New model is {self.n_since_renewal} epochs old")
             for param in self.weights_new:
                 self.weights_new[param] *= self.n_since_renewal
                 self.weights_new[param] += c_weights[param]
-                torch.true_div_(self.weights_new[param], self.n_since_renewal+1)
+                self.weights_new[param] = torch.true_div(self.weights_new[param], self.n_since_renewal+1)
             
     def _compare_averages(self) -> None:
         if self.loss is None:

--- a/lumin/nn/callbacks/model_callbacks.py
+++ b/lumin/nn/callbacks/model_callbacks.py
@@ -140,14 +140,14 @@ class SWA(AbsModelCallback):
         for param in self.weights:
             self.weights[param] *= self.swa_n
             self.weights[param] += c_weights[param]
-            torch.true_divide_(self.weights[param], self.swa_n+1)
+            self.weights[param] = torch.true_divide(self.weights[param], self.swa_n+1)
         
         if self.swa_n > self.renewal_period and self.first_completed and self.renewal_period > 0:
             if self.verbose: print(f"New model is {self.n_since_renewal} epochs old")
             for param in self.weights_new:
                 self.weights_new[param] *= self.n_since_renewal
                 self.weights_new[param] += c_weights[param]
-                torch.true_divide_(self.weights_new[param], self.n_since_renewal+1)
+                self.weights_new[param] = torch.true_divide(self.weights_new[param], self.n_since_renewal+1)
             
     def _compare_averages(self) -> None:
         if self.loss is None:

--- a/lumin/nn/callbacks/model_callbacks.py
+++ b/lumin/nn/callbacks/model_callbacks.py
@@ -141,14 +141,14 @@ class SWA(AbsModelCallback):
         for param in self.weights:
             self.weights[param] *= self.swa_n
             self.weights[param] += c_weights[param]
-            self.weights[param] /= self.swa_n+1
+            self.weights[param] /= float(self.swa_n+1)
         
         if self.swa_n > self.renewal_period and self.first_completed and self.renewal_period > 0:
             if self.verbose: print(f"New model is {self.n_since_renewal} epochs old")
             for param in self.weights_new:
                 self.weights_new[param] *= self.n_since_renewal
                 self.weights_new[param] += c_weights[param]
-                self.weights_new[param] /= (self.n_since_renewal+1)
+                self.weights_new[param] /= float(self.n_since_renewal+1)
             
     def _compare_averages(self) -> None:
         if self.loss is None:

--- a/lumin/nn/callbacks/model_callbacks.py
+++ b/lumin/nn/callbacks/model_callbacks.py
@@ -3,12 +3,11 @@ from typing import Optional, Dict
 from abc import abstractmethod
 import copy
 
-import torch.tensor as Tensor
+import torch
 
 from ..models.abs_model import AbsModel
 from .callback import Callback
 from .cyclic_callbacks import AbsCyclicCallback
-from ...utils.misc import to_tensor
 from ...plotting.plot_settings import PlotSettings
 
 __all__ = ['SWA', 'AbsModelCallback']
@@ -141,14 +140,14 @@ class SWA(AbsModelCallback):
         for param in self.weights:
             self.weights[param] *= self.swa_n
             self.weights[param] += c_weights[param]
-            self.weights[param] /= float(self.swa_n+1)
+            torch.true_div_(self.weights[param], self.swa_n+1)
         
         if self.swa_n > self.renewal_period and self.first_completed and self.renewal_period > 0:
             if self.verbose: print(f"New model is {self.n_since_renewal} epochs old")
             for param in self.weights_new:
                 self.weights_new[param] *= self.n_since_renewal
                 self.weights_new[param] += c_weights[param]
-                self.weights_new[param] /= float(self.n_since_renewal+1)
+                torch.true_div_(self.weights_new[param], self.n_since_renewal+1)
             
     def _compare_averages(self) -> None:
         if self.loss is None:

--- a/lumin/nn/data/fold_yielder.py
+++ b/lumin/nn/data/fold_yielder.py
@@ -273,7 +273,7 @@ class FoldYielder:
             if column == 'matrix_inputs' and self.matrix_is_sparse:
                 c = data[1:].astype(int)
                 data = sparse.COO(coords=c, data=data[0], shape=[c[0][-1]+1]+self.matrix_shape).todense()
-        return data[:, None] if data[0].shape is () and add_newaxis else data
+        return data[:, None] if data[0].shape == () and add_newaxis else data
 
     def get_data(self, n_folds:Optional[int]=None, fold_idx:Optional[int]=None) -> Dict[str,np.ndarray]:
         r'''

--- a/lumin/nn/data/fold_yielder.py
+++ b/lumin/nn/data/fold_yielder.py
@@ -144,7 +144,7 @@ class FoldYielder:
             self.matrix_shape = self.matrix_feats['shape'] if 'shape' in self.matrix_feats else False
 
     def _append_matrix(self, data, idx):
-        data['inputs'] = (data['inputs'],np.nan_to_num(self.get_column('matrix_inputs', n_folds=1, fold_idx=idx)))
+        data['inputs'] = (data['inputs'],self.get_column('matrix_inputs', n_folds=1, fold_idx=idx))
         return data
 
     def close(self) -> None:
@@ -223,7 +223,7 @@ class FoldYielder:
         r'''
         Get data for single fold. Data consists of dictionary of inputs, targets, and weights.
         Accounts for ignored features.
-        Inputs are passed through np.nan_to_num to deal with nans and infs.
+        Inputs, except for matrix data, are passed through np.nan_to_num to deal with nans and infs.
 
         Arguments:
             idx: fold index to load
@@ -236,9 +236,9 @@ class FoldYielder:
         if len(self._ignore_feats) == 0:
             return self._append_matrix(data, idx) if self.has_matrix and self.yield_matrix else data
         else:
-            inputs = pd.DataFrame(self.foldfile[f'fold_{idx}/inputs'][()], columns=self.input_feats)
-            inputs = inputs[[f for f in self.input_feats if f not in self._ignore_feats]]
-            data['inputs'] = np.nan_to_num(inputs.values)
+            inputs = pd.DataFrame(data['inputs'], columns=self.input_feats)
+            inputs = inputs[[f for f in self.input_feats if f not in self._ignore_feats]]  # TODO Improve this with preconfigured mask
+            data['inputs'] = inputs.values
             return self._append_matrix(data, idx) if self.has_matrix and self.yield_matrix else data
 
     def get_column(self, column:str, n_folds:Optional[int]=None, fold_idx:Optional[int]=None, add_newaxis:bool=False) -> Union[np.ndarray, None]:
@@ -278,7 +278,7 @@ class FoldYielder:
     def get_data(self, n_folds:Optional[int]=None, fold_idx:Optional[int]=None) -> Dict[str,np.ndarray]:
         r'''
         Get data for single, specified fold or several of folds. Data consists of dictionary of inputs, targets, and weights.
-        Does not accounts for ignored features.
+        Does not account for ignored features.
         Inputs are passed through np.nan_to_num to deal with nans and infs.
 
         Arguments:
@@ -483,7 +483,7 @@ class HEPAugFoldYielder(FoldYielder):
         r'''
         Get data for single fold applying random train-time data augmentaion. Data consists of dictionary of inputs, targets, and weights.
         Accounts for ignored features.
-        Inputs are passed through np.nan_to_num to deal with nans and infs.
+        Inputs, except for matrix data, are passed through np.nan_to_num to deal with nans and infs.
 
         Arguments:
             idx: fold index to load
@@ -528,7 +528,7 @@ class HEPAugFoldYielder(FoldYielder):
         r'''
         Get test data for single fold applying test-time data augmentaion. Data consists of dictionary of inputs, targets, and weights.
         Accounts for ignored features.
-        Inputs are passed through np.nan_to_num to deal with nans and infs.
+        Inputs, except for matrix data, are passed through np.nan_to_num to deal with nans and infs.
 
         Arguments:
             idx: fold index to load

--- a/lumin/nn/training/fold_train.py
+++ b/lumin/nn/training/fold_train.py
@@ -261,4 +261,3 @@ def fold_train_ensemble(fy:FoldYielder, n_models:int, bs:int, model_builder:Mode
         sys.stdout = old_stdout
         log_file.close()
     return results, histories, cycle_losses
-    

--- a/lumin/optimisation/hyper_param.py
+++ b/lumin/optimisation/hyper_param.py
@@ -121,7 +121,7 @@ def fold_lr_find(fy:FoldYielder, model_builder:ModelBuilder, bs:int,
         for c in callbacks:
             c.on_train_begin()
         lr_finder.on_train_begin()
-        batch_yielder = BatchYielder(**fy.get_fold(trn_id), objective=model_builder.objective, bs=bs, use_weights=train_on_weights, shuffle=shuffle_fold,
+        batch_yielder = BatchYielder(**trn_fold, objective=model_builder.objective, bs=bs, use_weights=train_on_weights, shuffle=shuffle_fold,
                                      bulk_move=bulk_move)
         model.fit(batch_yielder, callbacks+[lr_finder])
         lr_finders.append(lr_finder)

--- a/lumin/plotting/training.py
+++ b/lumin/plotting/training.py
@@ -17,7 +17,7 @@ def _lookup_name(name:str) -> str:
 
 
 def plot_train_history(histories:List[Dict[str,List[float]]], savename:Optional[str]=None, ignore_trn:bool=True, settings:PlotSettings=PlotSettings(),
-                       show:bool=True, x_lim:Optional[Tuple[int,int]]=None, log_y:bool=False) -> None:
+                       show:bool=True, xlow:int=0, log_y:bool=False) -> None:
     r'''
     Plot histories object returned by :meth:`~lumin.nn.training.fold_train.fold_train_ensemble` showing the loss evolution over time per model trained.
 
@@ -33,17 +33,16 @@ def plot_train_history(histories:List[Dict[str,List[float]]], savename:Optional[
         for i, history in enumerate(histories):
             if i == 0:
                 for j, l in enumerate(history):
-                    if not('trn' in l and ignore_trn): plt.plot(history[l], color=palette[j], label=_lookup_name(l))
+                    if not('trn' in l and ignore_trn): plt.plot(history[l][xlow:], color=palette[j], label=_lookup_name(l))
             else:
                 for j, l in enumerate(history):
-                    if not('trn' in l and ignore_trn): plt.plot(history[l], color=palette[j])
+                    if not('trn' in l and ignore_trn): plt.plot(history[l][xlow:], color=palette[j])
 
         plt.legend(loc=settings.leg_loc, fontsize=settings.leg_sz)
         plt.xticks(fontsize=settings.tk_sz, color=settings.tk_col)
         plt.yticks(fontsize=settings.tk_sz, color=settings.tk_col)
         plt.xlabel("Subepoch", fontsize=settings.lbl_sz, color=settings.lbl_col)
         plt.ylabel("Loss", fontsize=settings.lbl_sz, color=settings.lbl_col)
-        if x_lim is not None: plt.xlim(x_lim)
         if log_y:
             plt.yscale('log')
             plt.grid(b=True, which="both", axis="both")

--- a/lumin/plotting/training.py
+++ b/lumin/plotting/training.py
@@ -33,10 +33,10 @@ def plot_train_history(histories:List[Dict[str,List[float]]], savename:Optional[
         for i, history in enumerate(histories):
             if i == 0:
                 for j, l in enumerate(history):
-                    if not('trn' in l and ignore_trn): plt.plot(history[l][xlow:], color=palette[j], label=_lookup_name(l))
+                    if not('trn' in l and ignore_trn): plt.plot(range(xlow,len(history[l])), history[l][xlow:], color=palette[j], label=_lookup_name(l))
             else:
                 for j, l in enumerate(history):
-                    if not('trn' in l and ignore_trn): plt.plot(history[l][xlow:], color=palette[j])
+                    if not('trn' in l and ignore_trn): plt.plot(range(xlow,len(history[l])), history[l][xlow:], color=palette[j])
 
         plt.legend(loc=settings.leg_loc, fontsize=settings.leg_sz)
         plt.xticks(fontsize=settings.tk_sz, color=settings.tk_col)

--- a/lumin/plotting/training.py
+++ b/lumin/plotting/training.py
@@ -17,7 +17,7 @@ def _lookup_name(name:str) -> str:
 
 
 def plot_train_history(histories:List[Dict[str,List[float]]], savename:Optional[str]=None, ignore_trn:bool=True, settings:PlotSettings=PlotSettings(),
-                       show:bool=True) -> None:
+                       show:bool=True, x_lim:Optional[Tuple[int,int]]=None, log_y:bool=False) -> None:
     r'''
     Plot histories object returned by :meth:`~lumin.nn.training.fold_train.fold_train_ensemble` showing the loss evolution over time per model trained.
 
@@ -43,6 +43,10 @@ def plot_train_history(histories:List[Dict[str,List[float]]], savename:Optional[
         plt.yticks(fontsize=settings.tk_sz, color=settings.tk_col)
         plt.xlabel("Subepoch", fontsize=settings.lbl_sz, color=settings.lbl_col)
         plt.ylabel("Loss", fontsize=settings.lbl_sz, color=settings.lbl_col)
+        if x_lim is not None: plt.xlim(x_lim)
+        if log_y:
+            plt.yscale('log')
+            plt.grid(b=True, which="both", axis="both")
         if savename is not None: plt.savefig(settings.savepath/f'{savename}{settings.format}', bbox_inches='tight')
         if show: plt.show()
 


### PR DESCRIPTION
# Targeting V0.5.2

## Important changes

- Matrix data is no longer passed through `np.nan_to_num` in `FoldYielder`. Users should ensure that all values in matrix data are not NaN or Inf

## Breaking

## Additions

- Tensor data:
  - The matrices may also be passed as sparse format and be densified on loading by FoldYielder
- OneCycle `lr_range` now supports a non-zero final LR; just supply a three-tuple to the `lr_range` argument.

## Removals

## Fixes

- Unnecessary second loading of fold data in `fold_lr_find`
- Compatibility error when working in PyTorch 1.6 based on integer and true division

## Changes

- Matrix data is no longer passed through `np.nan_to_num` in `FoldYielder`. Users should ensure that all values in matrix data are not NaN or Inf

## Depreciations

## Comments
