### PR TITLE
Adding backwards compatibility for SWA in torch < 1.6

### DIFF
--- a/lumin/nn/callbacks/model_callbacks.py
+++ b/lumin/nn/callbacks/model_callbacks.py
@@ -2,6 +2,7 @@ import numpy as np
 from typing import Optional, Dict, List
 from abc import abstractmethod
 import copy
+from distutils.version import LooseVersion
 
 import torch
 
@@ -94,6 +95,7 @@ class SWA(AbsModelCallback):
         super().__init__(model=model, val_fold=val_fold, cyclic_callback=cyclic_callback, update_on_cycle_end=update_on_cycle_end, plot_settings=plot_settings)
         self.start_epoch,self.renewal_period,self.verbose = start_epoch,renewal_period,verbose
         self.weights,self.loss = None,None
+        self.true_div = True if LooseVersion(torch.__version__) >= LooseVersion("1.6") else False  # Integer division changed in PyTorch 1.6
         
     def on_train_begin(self, **kargs) -> None:
         r'''
@@ -142,14 +144,16 @@ class SWA(AbsModelCallback):
         for param in self.weights:
             self.weights[param] *= self.swa_n
             self.weights[param] += c_weights[param]
-            self.weights[param] = torch.true_divide(self.weights[param], self.swa_n+1)
+            if self.true_div: self.weights[param] = torch.true_divide(self.weights[param], self.swa_n+1)
+            else:             self.weights[param] /= self.swa_n+1
         
         if self.swa_n > self.renewal_period and self.first_completed and self.renewal_period > 0:
             if self.verbose: print(f"New model is {self.n_since_renewal} epochs old")
             for param in self.weights_new:
                 self.weights_new[param] *= self.n_since_renewal
                 self.weights_new[param] += c_weights[param]
-                self.weights_new[param] = torch.true_divide(self.weights_new[param], self.n_since_renewal+1)
+                if self.true_div: self.weights_new[param] = torch.true_divide(self.weights_new[param], self.n_since_renewal+1)
+                else:             self.weights_new[param] /= self.n_since_renewal+1
             
     def _compare_averages(self) -> None:
         if self.loss is None:


### PR DESCRIPTION
`true_division` was only added in 1.6, prior to that integer division works as expected