### PR TITLE
Memory fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
 - Bug in `train` when not passing any metrics
 - Bug in FoldYielder when loading output pipe from Path
 - Bug in `OneCycle` that prevented the model from stopping training at end of cycle
+- `start_mode_id` renamed to `start_model_id`
+- Bug in `ParametrisedPrediction`
 
 ## Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,14 +3,14 @@
 ## Important changes
 
 - Fixed bug in `Model.set_mom`  which resulted in momentum never being set (affects e.g. OneCycle and CyclicalMom)
-- `Model.fit` now shuffles the fold indeces for training folds prio to each epoch rather than once per training; removes the periodicity in trsining loss which was occaisionally apparent.
+- `Model.fit` now shuffles the fold indices for training folds prior to each epoch rather than once per training; removes the periodicity in training loss which was occasionally apparent.
 
 ## Breaking
 
 ## Additions
 
 - Mish activation function
-- `Model.fit_params.val_requires_grad` to control whether to compute validation epoch with gradient, default zero, buit some losses might require it in the future
+- `Model.fit_params.val_requires_grad` to control whether to compute validation epoch with gradient, default zero, built some losses might require it in the future
 
 ## Removals
 
@@ -28,8 +28,8 @@
 
 ## Changes
 
-- `Model.fit` now shuffles the fold indeces for training folds prio to each epoch rather than once per training; removes the periodicity in training loss which was occaisionally apparent.
-- Validation and prediction forwards passes now performed without gradient trackign to save memory and time
+- `Model.fit` now shuffles the fold indices for training folds prior to each epoch rather than once per training; removes the periodicity in training loss which was occasionally apparent.
+- Validation and prediction forwards passes now performed without gradient tracking to save memory and time
 
 ## Depreciations
 
@@ -39,7 +39,7 @@
 
 ## Important changes
 
-- `EvalMetrics` revised to inherit from `Callback` and be called on validation data after every epoch. User-written `EvalMetrics` willneed to be adjusted to work with the new calling method: adjust `evaluate` method and constructor may need to be adjusted; see existing metrics to see how.
+- `EvalMetrics` revised to inherit from `Callback` and be called on validation data after every epoch. User-written `EvalMetrics` will need to be adjusted to work with the new calling method: adjust `evaluate` method and constructor may need to be adjusted; see existing metrics to see how.
   
 ## Breaking
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 ## Additions
 
 - Mish activation function
+- `Model.fit_params.val_requires_grad` to control whether to compute validation epoch with gradient, default zero, buit some losses might require it in the future
 
 ## Removals
 
@@ -24,7 +25,8 @@
 
 ## Changes
 
-- `Model.fit` now shuffles the fold indeces for training folds prio to each epoch rather than once per training; removes the periodicity in trsining loss which was occaisionally apparent.
+- `Model.fit` now shuffles the fold indeces for training folds prio to each epoch rather than once per training; removes the periodicity in training loss which was occaisionally apparent.
+- Validation and prediction forwards passes now performed without gradient trackign to save memory and time
 
 ## Depreciations
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - Bug in `OneCycle` that prevented the model from stopping training at end of cycle
 - `start_mode_id` renamed to `start_model_id`
 - Bug in `ParametrisedPrediction`
+- Bug in `Model` predictions when running over a `FoldYielder` and passing a list of callbacks (even if empty)
 
 ## Changes
 

--- a/lumin/nn/callbacks/data_callbacks.py
+++ b/lumin/nn/callbacks/data_callbacks.py
@@ -348,4 +348,4 @@ class ParametrisedPrediction(Callback):
         Adjusts the data to be passed to the model by setting in place the parameterisation feature to the preset value
         '''
 
-        for f, v in zip(self.param_idx, self.param_val):  self.fit_params.by.inputs[:, f] = v
+        for f, v in zip(self.param_idx, self.param_val):  self.model.fit_params.by.inputs[:, f] = v

--- a/lumin/nn/models/model.py
+++ b/lumin/nn/models/model.py
@@ -246,6 +246,7 @@ class Model(AbsModel):
                 for c in self.fit_params.cbs: c.on_pred_end()
         finally:
             self.fit_params = None
+            torch.cuda.empty_cache()
         return pred_cb.get_preds()
 
     def _predict_array(self, inputs:Union[np.ndarray,pd.DataFrame,Tensor,Tuple], as_np:bool=True, pred_cb:PredHandler=PredHandler(),

--- a/lumin/nn/models/model.py
+++ b/lumin/nn/models/model.py
@@ -210,7 +210,7 @@ class Model(AbsModel):
 
             if self.fit_params.val_idx is not None:
                 self.model.eval()
-                with torch.set_grad_enabled(not self.fit_params.val_requires_grad):
+                with torch.set_grad_enabled(self.fit_params.val_requires_grad):
                     self.fit_params.state = 'valid'
                     for c in self.fit_params.cbs: c.on_epoch_begin()
                     self.fit_params.by = val_by if bulk_move else val_by(**self.fit_params.fy.get_fold(self.fit_params.val_idx))
@@ -240,7 +240,7 @@ class Model(AbsModel):
         try:
             for c in self.fit_params.cbs: c.set_model(self)
             self.model.eval()
-            with torch.set_grad_enabled(not self.fit_params.val_requires_grad):
+            with torch.set_grad_enabled(self.fit_params.val_requires_grad):
                 for c in self.fit_params.cbs: c.on_pred_begin()
                 for b in self.fit_params.by: self._fit_batch(*b)
                 for c in self.fit_params.cbs: c.on_pred_end()

--- a/lumin/nn/models/model.py
+++ b/lumin/nn/models/model.py
@@ -210,7 +210,7 @@ class Model(AbsModel):
 
             if self.fit_params.val_idx is not None:
                 self.model.eval()
-                with torch.no_grad():
+                with torch.set_grad_enabled(not self.fit_params.val_requires_grad):
                     self.fit_params.state = 'valid'
                     for c in self.fit_params.cbs: c.on_epoch_begin()
                     self.fit_params.by = val_by if bulk_move else val_by(**self.fit_params.fy.get_fold(self.fit_params.val_idx))
@@ -236,7 +236,7 @@ class Model(AbsModel):
         if cbs is None: cbs = []
         elif not is_listy(cbs): cbs = [cbs]
         cbs.append(pred_cb)
-        self.fit_params = FitParams(cbs=cbs, by=by, state='test')
+        self.fit_params = FitParams(cbs=cbs, by=by, state='test', val_requires_grad=False)
         try:
             for c in self.fit_params.cbs: c.set_model(self)
             self.model.eval()

--- a/lumin/nn/training/train.py
+++ b/lumin/nn/training/train.py
@@ -26,7 +26,7 @@ __all__ = ['train_models']
 
 def train_models(fy:FoldYielder, n_models:int, bs:int, model_builder:ModelBuilder, n_epochs:int, patience:Optional[int]=None, loss_is_meaned:bool=True,
                  cb_partials:Optional[List[Callable[[],Callback]]]=None, metric_partials:Optional[List[Callable[[],EvalMetric]]]=None,
-                 pred_cb:Callable[[],PredHandler]=PredHandler, train_on_weights:bool=True, bulk_move:bool=True, start_mode_id:int=0,
+                 pred_cb:Callable[[],PredHandler]=PredHandler, train_on_weights:bool=True, bulk_move:bool=True, start_model_id:int=0,
                  live_fdbk:bool=IN_NOTEBOOK, live_fdbk_first_only:bool=False, live_fdbk_extra:bool=True, live_fdbk_extra_first_only:bool=False,
                  savepath:Path=Path('train_weights'), plot_settings:PlotSettings=PlotSettings()) \
         -> Tuple[List[Dict[str,float]],List[Dict[str,List[float]]],List[Dict[str,float]]]:
@@ -63,7 +63,7 @@ def train_models(fy:FoldYielder, n_models:int, bs:int, model_builder:ModelBuilde
             Default simply returns the model predictions. Other uses could be e.g. running argmax on a multiclass classifier
         train_on_weights: If weights are present in training data, whether to pass them to the loss function during training
         bulk_move: if true, will optimise for speed by using more RAM and VRAM
-        start_mode_id: model ID at whcih to start training,
+        start_model_id: model ID at whcih to start training,
             i.e. if training was interupted, this can be set to resume training form the last model which was trained
         live_fdbk: whether or not to show any live feedback at all during training (slightly slows down training, but helps spot problems)
         live_fdbk_first_only: whether to only show live feedback for the first model trained (trade off between time and problem spotting)
@@ -84,7 +84,7 @@ def train_models(fy:FoldYielder, n_models:int, bs:int, model_builder:ModelBuilde
     if metric_partials is None: metric_partials = []
     if not is_listy(metric_partials): metric_partials = [metric_partials]
 
-    model_rng = range(start_mode_id, n_models)
+    model_rng = range(start_model_id, n_models)
     for i in model_rng: os.system(f"rm -r {savepath}/model_id_{i}")
     model_bar = master_bar(model_rng) if IN_NOTEBOOK else progress_bar(model_rng)
     train_tmr = timeit.default_timer()


### PR DESCRIPTION
# Targeting v0.7.2

## Important changes

## Breaking

## Additions

- `Model.fit_params.val_requires_grad` to control whether to compute validation epoch with gradient, default zero, built some losses might require it in the future

## Removals

## Fixes

- `start_mode_id` renamed to `start_model_id`
- Bug in `ParametrisedPrediction`
- Bug in `Model` predictions when running over a `FoldYielder` and passing a list of callbacks (even if empty)

## Changes

- Validation and prediction forwards passes now performed without gradient tracking to save memory and time

## Depreciations

## Comments