### PR TITLE
Regression additions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - `BackwardHook` for recording telemetric data during backwards passes
 - New losses:
     - `WeightedFractionalMSE`, `WeightedBinnedHuber`, `WeightedFractionalBinnedHuber`
+- Options for log x & y axis in `plot_feat`
 
 ## Removals
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,16 @@
     - Additional `bn_class` arguments to blocks, allowing the user to choose different batchnorm implementations
     - 1, 2, & 3D Running batchnorm layers from fastai (https://github.com/fastai/course-v3)
 - `GNNHead` encapsulating head for feature extraction, using `AbsGraphFeatExtractor` classes, and graph collapsing, using `GraphCollapser` classes
+- New callbacks:
+    - `AbsWeightData` to weight folds of data based on their inputs or targets
+    - `EpochSaver` to save the model to a new file at the end of every epoch
+    - `CycleStep` combines OneCycle and step-decay of optimiser hyper-parameters
+- New CNN blocks:
+    - `AdaptiveAvgMaxConcatPool1d`, `AdaptiveAvgMaxConcatPool2d`, `AdaptiveAvgMaxConcatPool3d` use average and maximum pooling to reduce data to specified number sizes per channel
+    - `SEBlock1d`, `SEBlock2d`, `SEBlock3d` apply squeeze-excitation to data channels
+- `BackwardHook` for recording telemetric data during backwards passes
+- New losses:
+    - `WeightedFractionalMSE`, `WeightedBinnedHuber`, `WeightedFractionalBinnedHuber`
 
 ## Removals
 
@@ -63,6 +73,7 @@
 
 - `padding` argument in conv 1D blocks renamed to pad
 - Graph nets: generalised into feature extraction for features per vertex and graph collapsing down to flat data (with optional self-attention)
+- Renamed `FowardHook` to `ForwardHook`
 
 ## Depreciations
 
@@ -188,7 +199,7 @@
 
 ## Additions
 
-- `__del__` method to `FowardHook` class
+- `__del__` method to `ForwardHook` class
 - `BatchYielder`:
     - Now takes an `input_mask` argument to filter inputs
     - Now takes an argument allowing incomplete batches to be yielded

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,7 @@
 - `padding` argument in conv 1D blocks renamed to pad
 - Graph nets: generalised into feature extraction for features per vertex and graph collapsing down to flat data (with optional self-attention)
 - Renamed `FowardHook` to `ForwardHook`
+- Abstract classes no longer inherit from ABC, but rather have `metaclass=ABCMeta` in order to be compatible with py>=3.7
 
 ## Depreciations
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For an introduction and motivation for LUMIN, checkout this talk from IML-2019 a
         - Graph nets for physics objects, e.g. [Battaglia, Pascanu, Lai, Rezende, Kavukcuoglu, 2016](https://arxiv.org/abs/1612.00222), [Moreno et al., 2019](https://arxiv.org/abs/1908.05318), and [Qasim, Kieseler, Iiyama, & Pierini, 2019](https://link.springer.com/article/10.1140/epjc/s10052-019-7113-9), with optional self-attention [Vaswani et al., 2017](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf).
         - Recurrent layers for series of objects
         - 1D convolutional networks for series of objects
+        - Squeeze-excitation blocks [Hu, Shen, Albanie, Sun, & Wu, 2017](https://arxiv.org/abs/1709.01507)
         - HEP-specific architectures, e.g. LorentzBoostNetworks [Erdmann, Geiser, Rath, Rieger, 2018](https://arxiv.org/abs/1812.09722)
 - Configurable initialisations, including LSUV [Mishkin, Matas, 2016](https://arxiv.org/abs/1511.06422)
 - HEP-specific losses, e.g. Asimov loss [Elwood & Krücker, 2018](https://arxiv.org/abs/1806.00322)

--- a/docs/source/description.md
+++ b/docs/source/description.md
@@ -38,6 +38,7 @@
         - Graph nets for physics objects, e.g. [Battaglia, Pascanu, Lai, Rezende, Kavukcuoglu, 2016](https://arxiv.org/abs/1612.00222), [Moreno et al., 2019](https://arxiv.org/abs/1908.05318), and [Qasim, Kieseler, Iiyama, & Pierini, 2019](https://link.springer.com/article/10.1140/epjc/s10052-019-7113-9), with optional self-attention [Vaswani et al., 2017](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf).
         - Recurrent layers for series of objects
         - 1D convolutional networks for series of objects
+        - Squeeze-excitation blocks [Hu, Shen, Albanie, Sun, & Wu, 2017](https://arxiv.org/abs/1709.01507)
         - HEP-specific architectures, e.g. LorentzBoostNetworks [Erdmann, Geiser, Rath, Rieger, 2018](https://arxiv.org/abs/1812.09722)
 - Configurable initialisations, including LSUV [Mishkin, Matas, 2016](https://arxiv.org/abs/1511.06422)
 - HEP-specific losses, e.g. Asimov loss [Elwood & Krücker, 2018](https://arxiv.org/abs/1806.00322)

--- a/examples/Advanced_Model_Building.ipynb
+++ b/examples/Advanced_Model_Building.ipynb
@@ -1494,11 +1494,11 @@
    "source": [
     "from typing import Union\n",
     "from torch import Tensor\n",
-    "from lumin.utils.misc import FowardHook, to_np\n",
+    "from lumin.utils.misc import ForwardHook, to_np\n",
     "\n",
     "def get_bottleneck_output(model:Model, bottleneck_idx:int, inputs:Union[np.ndarray,Tensor]) -> np.ndarray:\n",
     "    bn = model.body.bottleneck_blocks[bottleneck_idx]\n",
-    "    hook = FowardHook(bn[-1])\n",
+    "    hook = ForwardHook(bn[-1])\n",
     "    model.predict(inputs)\n",
     "    return to_np(hook.output.squeeze())"
    ]

--- a/lumin/nn/callbacks/abs_callback.py
+++ b/lumin/nn/callbacks/abs_callback.py
@@ -1,10 +1,7 @@
-from abc import ABC
-
-
 __all__ = []
     
 
-class AbsCallback(ABC):
+class AbsCallback():
     r'''
     Abstract callback passing though all action points and indicating where callbacks can affect the model.
     See :meth:`~lumin.nn.models.model.Model.fit` and :meth:`~lumin.nn.models.model.Model.predict_by` to see where exactly these action points are called.

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Tuple, Union, List
 from fastcore.all import store_attr
-from fastprogress import IN_NOTEBOOK
+from fastprogress.fastprogress import IN_NOTEBOOK
 
 from .callback import Callback
 from .monitors import EarlyStopping, SaveBest

--- a/lumin/nn/callbacks/cyclic_callbacks.py
+++ b/lumin/nn/callbacks/cyclic_callbacks.py
@@ -1,13 +1,15 @@
 import numpy as np
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 from fastcore.all import store_attr
+from fastprogress import IN_NOTEBOOK
 
 from .callback import Callback
+from .monitors import EarlyStopping, SaveBest
 
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-__all__ = ['AbsCyclicCallback', 'CycleLR', 'CycleMom', 'OneCycle']
+__all__ = ['AbsCyclicCallback', 'CycleLR', 'CycleMom', 'OneCycle', 'CycleStep']
 
 
 class AbsCyclicCallback(Callback):
@@ -252,3 +254,98 @@ class OneCycle(AbsCyclicCallback):
                 ax.tick_params(axis='x', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
                 ax.tick_params(axis='y', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
             plt.show()
+
+
+class CycleStep(OneCycle):
+    r'''
+    Combination of 1-cycle and step decay. Initial 1-cycle finishes, and step decay begins starting from best performing model and optimiser.
+
+    Arguments:
+        frac_reduction: fractional reduction of the learning rate with each step
+        patience: number of epochs to wait before step
+        lengths: OneCycle lengths
+        lr_range: OneCycle learning rates. Don't have the final LR be too small.
+        mom_range: OneCycle momenta,
+        interp: Iterpolation mode for OneCycle
+        plot_params: If true, will plot the parameter history at the end of training.
+    '''
+
+    def __init__(self, frac_reduction:float, patience:int, lengths:Tuple[int,int], lr_range:List[float], mom_range:Tuple[float,float]=(0.85, 0.95),
+                 interp:str='cosine', plot_params:bool=False):
+        super().__init__(lengths=lengths, lr_range=lr_range, mom_range=mom_range, interp=interp, cycle_ends_training=False)
+        self.frac_reduction,self.patience,self.plot_params = frac_reduction,patience,plot_params
+        
+    def on_train_begin(self):
+        r'''
+        Reset parameters, and check other callbacks in training.
+        '''
+
+        super().on_train_begin()
+        sb,self.early_stopping,self.stepping = False,False,False
+        for c in self.model.fit_params.cbs:
+            if isinstance(c, EarlyStopping): self.early_stopping = c
+            if isinstance(c, SaveBest): sb = True
+        if not(sb and self.early_stopping): raise ValueError("List of training callbacks must include both EarlyStopping and SaveBest callbacks")
+            
+    def _set_params(self) -> None:
+        if not self.stepping:
+            self.lr = self.model.opt.param_groups[0]['lr']
+            self.mom = self.model.opt.param_groups[0]['betas'][0] if 'betas' in self.model.opt.param_groups[0] else self.model.opt.param_groups[0]['momentum']
+        else:
+            self.lr *= self.frac_reduction
+            self.mom = self.mom_range[1]
+        self.model.set_lr(self.lr)
+        self.model.set_mom(self.mom)
+        
+    def on_batch_begin(self) -> None:
+        r'''
+        Computes the new lr and momentum and assigns them to the optimiser
+        '''
+        
+        if self.model.fit_params.state != 'train': return
+        if self.cycle_count == 1 and not self.stepping:  # Finished OneCycle
+            self.model.load(self.model.fit_params.cb_savepath/'best.h5')
+            self.cycle_end = True  # EarlyStopping can now end training
+            self._set_params()
+            self.stepping = True
+        if self.stepping:
+            self.hist['lr'].append(self.lr)
+            self.hist['mom'].append(self.mom)
+        else:
+            super().on_batch_begin()
+        
+    def on_epoch_begin(self) -> None:
+        r'''
+        Increment parameters if stepping
+        '''
+
+        super().on_epoch_begin()
+        self.cycle_end = self.stepping
+        if self.model.fit_params.state != 'valid': return
+        if self.early_stopping.epochs >= self.patience: self._set_params()
+        
+    def on_train_end(self) -> None:
+        r'''
+        Optionally plot the parameter history.
+        '''
+
+        if self.plot_params:self.plot()
+        
+    def plot(self):
+        r'''
+        Plots the history of the lr and momentum evolution as a function of iterations
+        '''
+
+        with sns.axes_style(self.plot_settings.style), sns.color_palette(self.plot_settings.cat_palette):
+            fig, axs = plt.subplots(2, 1, figsize=(self.plot_settings.w_mid, self.plot_settings.h_mid))
+            axs[1].set_xlabel("Iterations", fontsize=self.plot_settings.lbl_sz, color=self.plot_settings.lbl_col)
+            axs[0].set_ylabel("Learning Rate", fontsize=self.plot_settings.lbl_sz, color=self.plot_settings.lbl_col)
+            axs[1].set_ylabel("Momentum", fontsize=self.plot_settings.lbl_sz, color=self.plot_settings.lbl_col)
+            axs[0].plot(range(len(self.hist['lr'])), self.hist['lr'])
+            axs[1].plot(range(len(self.hist['mom'])), self.hist['mom'])
+            for ax in axs:
+                ax.tick_params(axis='x', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
+                ax.tick_params(axis='y', labelsize=self.plot_settings.tk_sz, labelcolor=self.plot_settings.tk_col)
+            plt.savefig(self.model.fit_params.cb_savepath/f'StepCycle_history{self.plot_settings.format}', bbox_inches='tight')            
+            if IN_NOTEBOOK: plt.show()
+            else:           plt.close(fig)

--- a/lumin/nn/callbacks/data_callbacks.py
+++ b/lumin/nn/callbacks/data_callbacks.py
@@ -1,7 +1,7 @@
 from typing import Union, Tuple, List, Optional
 import numpy as np
 from fastcore.all import is_listy, store_attr
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 
 import torch
 from torch import Tensor
@@ -183,7 +183,7 @@ class TargReplace(Callback):
         self.model.fit_params.by.targets = self.model.fit_params.fy.get_column('targets', n_folds=1, fold_idx=self.model.fit_params.val_idx, add_newaxis=True)
 
 
-class AbsWeightData(Callback):
+class AbsWeightData(Callback, metaclass=ABCMeta):
     r'''
     Callback to weight folds of data accoridng to a function of the inputs or targets.
     Inherit and override the `weight_func` method according to your task.

--- a/lumin/nn/callbacks/monitors.py
+++ b/lumin/nn/callbacks/monitors.py
@@ -11,7 +11,7 @@ import seaborn as sns
 
 from .callback import Callback
 
-__all__ = ['EarlyStopping', 'SaveBest', 'MetricLogger']
+__all__ = ['EarlyStopping', 'SaveBest', 'MetricLogger', 'EpochSaver']
 
 
 class EarlyStopping(Callback):
@@ -391,3 +391,26 @@ class MetricLogger(Callback):
         if len(self.metric_cbs) > 0:
             for c,v in zip(self.metric_cbs,metrics[:,idx]): results[c.name] = v
         return results
+
+
+class EpochSaver(Callback):
+    r'''
+    Callback to save the model at the end of every epoch, regarless of improvement
+    '''
+
+    def on_train_begin(self) -> None:
+        r'''
+        Reset epoch count
+        '''
+
+        super().on_train_begin()
+        self.epoch = 1
+
+    def on_epoch_end(self):
+        r'''
+        Save the model at the end of each validation epoch to a new file
+        '''
+
+        if self.model.fit_params.state != 'train': return
+        self.model.save(self.model.fit_params.cb_savepath/f'epoch_{self.epoch}.h5')
+        self.epoch += 1

--- a/lumin/nn/ensemble/abs_ensemble.py
+++ b/lumin/nn/ensemble/abs_ensemble.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Union, List, Optional, Tuple
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 from ..models.abs_model import AbsModel
 from ..data.fold_yielder import FoldYielder
@@ -8,7 +8,7 @@ from ..data.fold_yielder import FoldYielder
 __all__ = []
 
 
-class AbsEnsemble(ABC):
+class AbsEnsemble(metaclass=ABCMeta):
     '''Abstract classs for ensembles'''
     def __init__(self): self.models,self.weights,self.size = [],[],0
 

--- a/lumin/nn/ensemble/ensemble.py
+++ b/lumin/nn/ensemble/ensemble.py
@@ -331,7 +331,7 @@ class Ensemble(AbsEnsemble):
                 Default simply returns the model predictions. Other uses could be e.g. running argmax on a multiclass classifier
             cbs: list of any instantiated callbacks to use during prediction
             bs: if not `None`, will run prediction in batches of specified size to save of memory
-            auto_deprocess: if true and ensemble has an putput_pipe, will inverse-transform predictions
+            auto_deprocess: if true and ensemble has an output_pipe, will inverse-transform predictions
 
         Returns:
             if inputs are a Numpy array, Pandas DataFrame, or tensor, will return predicitions as either array or tensor

--- a/lumin/nn/interpretation/features.py
+++ b/lumin/nn/interpretation/features.py
@@ -112,6 +112,8 @@ def get_ensemble_feat_importance(ensemble:AbsEnsemble, fy:FoldYielder, bs:Option
         >>>
         >>> fi = get_ensemble_feat_importance(ensemble, train_fy,
         ...                                   eval_metric=AMS(n_total=100000))
+
+    TODO: Weight models
     '''
 
     mean_fi = []

--- a/lumin/nn/losses/advanced_losses.py
+++ b/lumin/nn/losses/advanced_losses.py
@@ -1,0 +1,134 @@
+from typing import Optional
+
+import torch
+from torch import nn, Tensor
+
+from ...utils.misc import to_device
+
+__all__ = ['WeightedFractionalMSE', 'WeightedBinnedHuber', 'WeightedFractionalBinnedHuber']
+
+
+class WeightedFractionalMSE(nn.MSELoss):
+    r'''
+    Class for computing the Mean fractional Squared-Error loss (<Delta^2/true>) with optional weights per prediction.
+    For compatability with using basic PyTorch losses, weights are passed during initialisation rather than when computing the loss.
+    
+    Arguments:
+        weight: sample weights as PyTorch Tensor, to be used with data to be passed when computing the loss
+
+    Examples::
+        >>> loss = WeightedFractionalMSE()
+        >>>
+        >>> loss = WeightedFractionalMSE(weights)
+    '''
+
+    def __init__(self, weight:Optional[Tensor]=None):
+        super().__init__(reduction='none')
+        self.weights = weight
+        
+    def forward(self, input:Tensor, target:Tensor) -> Tensor:
+        r'''
+        Evaluate loss for given predictions
+
+        Arguments:
+            input: prediction tensor
+            target: target tensor
+        
+        Returns:
+            (weighted) loss
+        '''
+
+        if self.weights is not None: return torch.mean(self.weights*super().forward(input, target)/target)
+        else:                        return torch.mean(super().forward(input, target)/target)
+
+
+class WeightedBinnedHuber(nn.MSELoss):
+    r'''
+    Class for computing the Huberised Mean Squared-Error loss (<Delta^2>) with optional weights per prediction.
+    Losses soft-clamped with Huber like term above adaptive percentile in bins of the target.
+    The thresholds used to transition from MSE to MAE per bin are initialised using the first batch of data as the value of the specified percentile in each bin,
+    subsequently, the thresholds evolve according to: T <- (1-mom)*T + mom*T_batch, where T_batch are the percentiles comuted on the current batch, and mom(emtum)
+    lies between [0,1]
+
+    For compatability with using basic PyTorch losses, weights are passed during initialisation rather than when computing the loss.
+    
+    Arguments:
+        perc: quantile of data in each bin above which to use MAE rather than MSE
+        bins: tensor of edges for the binning of the target data
+        mom: momentum for the running average of the thresholds
+        weight: sample weights as PyTorch Tensor, to be used with data to be passed when computing the loss
+
+    Examples::
+        >>> loss = WeightedBinnedHuber(perc=0.68)
+        >>>
+        >>> loss = WeightedBinnedHuber(perc=0.68, weights=weights)
+    '''
+
+    def __init__(self, perc:float, bins:Tensor, mom=0.1, weight:Optional[Tensor]=None):
+        super().__init__(reduction='none')
+        self.perc,self.bins,self.weights,self.mom = perc,bins,weight,mom
+        self.kths = to_device(torch.zeros_like(self.bins[:-1])-1)
+
+    def _compute_losses(self, input:Tensor, target:Tensor) -> Tensor:
+        loss = super().forward(input, target)  # MSE
+        # MAE
+        for i in range(len(self.bins)-1):
+            m = (target >= self.bins[i])*(target < self.bins[i+1])
+            if m.sum() == 0: continue
+            kth = loss[m].view(-1).kthvalue(1+round(self.perc*(loss[m].numel()-1))).values.detach()
+            if self.kths[i] < 0: self.kths[i] = kth
+            else:                self.kths[i].lerp_(kth, self.mom)
+            m = m*(loss > self.kths[i])
+            d = torch.sqrt(self.kths[i])
+            loss[m] = self.kths[i]+(2*d*((torch.abs(input[m]-target[m]))-d))
+        if self.weights is not None: loss = loss*self.weights
+        return loss
+        
+    def forward(self, input:Tensor, target:Tensor) -> Tensor:
+        r'''
+        Evaluate loss for given predictions
+
+        Arguments:
+            input: prediction tensor
+            target: target tensor
+        
+        Returns:
+            (weighted) loss
+        '''
+        
+        loss = self._compute_losses(input, target)
+        return torch.mean(loss)
+
+
+class WeightedFractionalBinnedHuber(WeightedBinnedHuber):
+    r'''
+    Class for computing the Huberised Mean fractional Squared-Error loss (<Delta^2/true>) with optional weights per prediction.
+    Losses soft-clamped with Huber like term above adaptive percentile in bins of the target.
+    The thresholds used to transition from MSE to MAE per bin are initialised using the first batch of data as the value of the specified percentile in each bin,
+    subsequently, the thresholds evolve according to: T <- (1-mom)*T + mom*T_batch, where T_batch are the percentiles comuted on the current batch, and mom(emtum)
+    lies between [0,1]
+
+    For compatability with using basic PyTorch losses, weights are passed during initialisation rather than when computing the loss.
+    
+    Arguments:
+        perc: quantile of data in each bin above which to use MAE rather than MSE
+        bins: tensor of edges for the binning of the target data
+        mom: momentum for the running average of the thresholds
+        weight: sample weights as PyTorch Tensor, to be used with data to be passed when computing the loss
+    '''
+        
+    def forward(self, input:Tensor, target:Tensor) -> Tensor:
+        r'''
+        Evaluate loss for given predictions
+
+        Arguments:
+            input: prediction tensor
+            target: target tensor
+        
+        Returns:
+            (weighted) loss
+        '''
+        
+        loss = self._compute_losses(input, target)
+        loss = loss/target
+        return torch.mean(loss)

--- a/lumin/nn/metrics/eval_metric.py
+++ b/lumin/nn/metrics/eval_metric.py
@@ -111,7 +111,7 @@ class EvalMetric(Callback, metaclass=ABCMeta):
 
         self.model = model
         preds = self.model.predict(inputs, bs=bs)
-        return self.evaluate_preds(fy=fy, fold_idx=fold_idx, preds=preds, targets=targets, weights=weights, bs=bs)
+        return self.evaluate_preds(fy=fy, fold_idx=fold_idx, preds=preds, targets=targets, weights=weights)
 
     def evaluate_preds(self, fy:FoldYielder, fold_idx:int, preds:np.ndarray, targets:np.ndarray, weights:Optional[np.ndarray]=None) -> float:
         r'''

--- a/lumin/nn/metrics/eval_metric.py
+++ b/lumin/nn/metrics/eval_metric.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 from typing import Optional
 from fastcore.all import store_attr
 
@@ -14,7 +14,7 @@ from ...utils.misc import to_np
 __all__ = ['EvalMetric']
 
 
-class EvalMetric(Callback):
+class EvalMetric(Callback, metaclass=ABCMeta):
     r'''
     Abstract class for evaluating performance of a model using some metric
 

--- a/lumin/nn/models/abs_model.py
+++ b/lumin/nn/models/abs_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from typing import List, Optional, Union, Generator, Callable
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 from torch.tensor import Tensor
 from torch import optim
@@ -18,7 +18,7 @@ class FitParams():
         self.epoch,self.sub_epoch = 0,0
 
 
-class AbsModel(ABC):
+class AbsModel(metaclass=ABCMeta):
     '''Abstract model class for typing'''
     def __init__(self): pass
     

--- a/lumin/nn/models/blocks/abs_block.py
+++ b/lumin/nn/models/blocks/abs_block.py
@@ -1,5 +1,5 @@
 from typing import Callable, Optional
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 
 from torch import Tensor
 import torch.nn as nn
@@ -9,7 +9,7 @@ from ..initialisations import lookup_normal_init
 __all__ = []
 
 
-class AbsBlock(nn.Module):
+class AbsBlock(nn.Module, metaclass=ABCMeta):
     def __init__(self, lookup_init:Callable[[str,Optional[int],Optional[int]],Callable[[Tensor],None]]=lookup_normal_init, freeze:bool=False):
         self.lookup_init,self.freeze = lookup_init,freeze
         super().__init__()

--- a/lumin/nn/models/blocks/endcap.py
+++ b/lumin/nn/models/blocks/endcap.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from typing import Union
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 
 import torch.nn as nn
 from torch import Tensor
@@ -11,7 +11,7 @@ from ....utils.misc import to_np
 __all__ = ['AbsEndcap']
 
 
-class AbsEndcap(nn.Module):
+class AbsEndcap(nn.Module, metaclass=ABCMeta):
     r'''
     Abstract class for constructing post training layer which performs further calculation on NN outputs.
     Used when NN was trained to some proxy objective

--- a/lumin/nn/models/blocks/gnn_blocks.py
+++ b/lumin/nn/models/blocks/gnn_blocks.py
@@ -1,6 +1,6 @@
 from typing import List, Callable, Any, Optional, Tuple, Union, Dict
 from fastcore.all import store_attr, is_listy
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 import numpy as np
 from functools import partial
 
@@ -53,7 +53,7 @@ class AbsGraphBlock(nn.Module):
         return nn.Sequential(*layers)
 
 
-class AbsGraphFeatExtractor(AbsGraphBlock):
+class AbsGraphFeatExtractor(AbsGraphBlock, metaclass=ABCMeta):
     r'''
     Abstract class for implementing feature extraction for graph neural-network blocks.
     Overridden `forward` should return features per vertex.

--- a/lumin/nn/models/blocks/head.py
+++ b/lumin/nn/models/blocks/head.py
@@ -4,7 +4,7 @@ from glob import glob
 from collections import OrderedDict
 from pathlib import Path
 import os
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 from functools import partial
 from distutils.version import LooseVersion
 
@@ -26,7 +26,7 @@ from .conv_blocks import Conv1DBlock, Res1DBlock, ResNeXt1DBlock
 __all__ = ['CatEmbHead', 'MultiHead', 'GNNHead', 'RecurrentHead', 'AbsConv1dHead', 'LorentzBoostNet', 'AutoExtractLorentzBoostNet']
 
 
-class AbsHead(AbsBlock):
+class AbsHead(AbsBlock, metaclass=ABCMeta):
     def __init__(self, cont_feats:List[str], cat_embedder:Optional[CatEmbedder]=None, 
                  lookup_init:Callable[[str,Optional[int],Optional[int]],Callable[[Tensor],None]]=lookup_normal_init, freeze:bool=False):
         super().__init__(lookup_init=lookup_init, freeze=freeze)

--- a/lumin/nn/models/blocks/tail.py
+++ b/lumin/nn/models/blocks/tail.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import Optional, Union, Tuple, Callable, List
-from abc import abstractmethod
 
 from ..initialisations import lookup_normal_init
 from ....utils.misc import to_device

--- a/lumin/optimisation/features.py
+++ b/lumin/optimisation/features.py
@@ -90,7 +90,7 @@ def rf_rank_features(train_df:pd.DataFrame, val_df:pd.DataFrame, objective:str,
         rf = m(**rfp)
         rf.fit(X=train_df[train_feats], y=train_df[targ_name], sample_weight=w_trn)
     
-    if verbose: print("Evalualting importances")
+    if verbose: print("Evaluating importances")
     fi = get_rf_feat_importance(rf, train_df[train_feats], train_df[targ_name], w_trn)
     orig_score = [rf.score(X=val_df[train_feats], y=val_df[targ_name], sample_weight=w_val)]
     if n_rfs > 1:

--- a/lumin/plotting/data_viewing.py
+++ b/lumin/plotting/data_viewing.py
@@ -17,7 +17,8 @@ __all__ = ['plot_feat', 'compare_events', 'plot_rank_order_dendrogram', 'plot_kd
 def plot_feat(df:pd.DataFrame, feat:str, wgt_name:Optional[str]=None, cuts:Optional[List[pd.Series]]=None,
               labels:Optional[List[str]]='', plot_bulk:bool=True, n_samples:int=100000,
               plot_params:Optional[Union[Dict[str,Any],List[Dict[str,Any]]]]=None, size:str='mid', show_moments:bool=True,
-              ax_labels:Dict[str,Any]={'y': 'Density', 'x': None}, savename:Optional[str]=None, settings:PlotSettings=PlotSettings()) -> None:
+              ax_labels:Dict[str,Any]={'y': 'Density', 'x': None}, log_x:bool=False, log_y:bool=False, savename:Optional[str]=None,
+              settings:PlotSettings=PlotSettings()) -> None:
     r'''
     A flexible function to provide indicative information about the 1D distribution of a feature.
     By default it will produce a weighted KDE+histogram for the [1,99] percentile of the data,
@@ -42,6 +43,8 @@ def plot_feat(df:pd.DataFrame, feat:str, wgt_name:Optional[str]=None, cuts:Optio
         size: string to pass to :meth:`~lumin.plotting.plot_settings.PlotSettings.str2sz` to determin size of plot
         show_moments: whether to compute and display the mean and standard deviation
         ax_labels: dictionary of x and y axes labels
+        log_x: if true, will use log scale for x-axis
+        log_y: if true, will use log scale for y-axis
         savename: Optional name of file to which to save the plot of feature importances
         settings: :class:`~lumin.plotting.plot_settings.PlotSettings` class to control figure appearance
     '''
@@ -90,6 +93,9 @@ def plot_feat(df:pd.DataFrame, feat:str, wgt_name:Optional[str]=None, cuts:Optio
             sns.distplot(plot_data, label=label, **tmp_plot_params)
 
         if len(cuts) > 1 or show_moments: plt.legend(loc=settings.leg_loc, fontsize=settings.leg_sz)
+        if log_y: plt.yscale('log')
+        if log_x: plt.xscale('log')
+        if log_y or log_x: plt.grid(which="both", axis="y" if log_y and not log_x else "x" if log_x and not log_y else 'both')
         plt.xticks(fontsize=settings.tk_sz, color=settings.tk_col)
         plt.yticks(fontsize=settings.tk_sz, color=settings.tk_col)
         plt.ylabel(ax_labels['y'], fontsize=settings.lbl_sz, color=settings.lbl_col)

--- a/lumin/plotting/interpretation.py
+++ b/lumin/plotting/interpretation.py
@@ -13,7 +13,7 @@ import torch
 from torch import Tensor
 
 from .plot_settings import PlotSettings
-from ..utils.misc import to_np, FowardHook
+from ..utils.misc import to_np, ForwardHook
 from ..utils.mod_ver import check_pdpbox
 from ..nn.models.abs_model import AbsModel
 
@@ -236,7 +236,7 @@ def plot_multibody_weighted_outputs(model:AbsModel, inputs:Union[np.ndarray,Tens
     else:
         block_names = [f'{i}' for i in range(len(model.body.blocks))]
     
-    hook = FowardHook(model.tail[0])
+    hook = ForwardHook(model.tail[0])
     model.predict(inputs)
     
     y, itr = [], 0
@@ -277,7 +277,7 @@ def plot_bottleneck_weighted_inputs(model:AbsModel, bottleneck_idx:int, inputs:U
     bn = body.bottleneck_blocks[bottleneck_idx]
     assert bn[0].weight.shape[0] == 1, 'This function currently only supports bottlenecks whose width is one neuron'
     
-    hook = FowardHook(bn[0])
+    hook = ForwardHook(bn[0])
     model.predict(inputs)
     
     weighted_input = to_np(torch.abs(hook.input[0]*bn[0].weight[0]))


### PR DESCRIPTION
# Targeting v0.8.0

## Important changes

## Breaking

## Additions

- New callbacks:
    - `AbsWeightData` to weight folds of data based on their inputs or targets
    - `EpochSaver` to save the model to a new file at the end of every epoch
    - `CycleStep` combines OneCycle and step-decay of optimiser hyper-parameters
- New CNN blocks:
    - `AdaptiveAvgMaxConcatPool1d`, `AdaptiveAvgMaxConcatPool2d`, `AdaptiveAvgMaxConcatPool3d` use average and maximum pooling to reduce data to specified number sizes per channel
    - `SEBlock1d`, `SEBlock2d`, `SEBlock3d` apply squeeze-excitation to data channels
- `BackwardHook` for recording telemetric data during backwards passes
- New losses:
    - `WeightedFractionalMSE`, `WeightedBinnedHuber`, `WeightedFractionalBinnedHuber`
- Options for log x & y axis in `plot_feat`

## Removals

## Fixes

## Changes

- Renamed `FowardHook` to `ForwardHook`
- Abstract classes no longer inherit from ABC, but rather have `metaclass=ABCMeta` in order to be compatible with py>=3.7

## Depreciations

- `OldInteractionNet` replaced in favour of `InteractionNet` feature extractor. Will be removed in v0.9

## Comments