### PR TITLE
No test shuffle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - `absmax` aggregation method for `GravNet` and `GraphCollapser`
 - 'hard_identity' function to replace lambda x: x when required
 - `fold2foldfile`, `df2foldfile`, and `add_meta_data` can now deal with targets in the form of multi dimensional tensors, and convert them to sparse COO format
+- `df2foldfile` now has the option to not shuffle data into folds and instead split it into contiguous folds
 
 ## Removals
 

--- a/lumin/data_processing/file_proc.py
+++ b/lumin/data_processing/file_proc.py
@@ -159,8 +159,8 @@ def df2foldfile(df:Optional[pd.DataFrame], n_folds:int, cont_feats:List[str], ca
             The format is `coo_x = sparse.as_coo(x); m = np.vstack((coo_x.data, coo_x.coords))`, where `m` is the tensor passed to `tensor_target`.
     '''
 
-    if shuffle and ('test' in savename or 'tst' in savename): print('Testing data will be shuffled, pass shuffle=Flase is this is not desired')
     savename = str(savename)
+    if shuffle and ('test' in savename or 'tst' in savename): print('Testing data will be shuffled, pass shuffle=Flase is this is not desired')
     os.system(f'rm {savename}.hdf5')
     os.makedirs(savename[:savename.rfind('/')], exist_ok=True)
     out_file = h5py.File(f'{savename}.hdf5', "w")

--- a/lumin/data_processing/file_proc.py
+++ b/lumin/data_processing/file_proc.py
@@ -175,16 +175,15 @@ def df2foldfile(df:Optional[pd.DataFrame], n_folds:int, cont_feats:List[str], ca
             print(f'{dup} present in both matrix features and continuous features; removing from continuous features')
             cont_feats = [f for f in cont_feats if f not in dup]
 
-    if shuffle:
-        if strat_key is not None and strat_key not in df.columns:
-            print(f'{strat_key} not found in DataFrame')
-            strat_key = None
-        if strat_key is None or shuffle is False:
-            kf = KFold(n_splits=n_folds, shuffle=shuffle)
-            folds = kf.split(X=df if df is not None else tensor_data)
-        else:
-            kf = StratifiedKFold(n_splits=n_folds, shuffle=True)
-            folds = kf.split(X=df, y=df[strat_key])
+    if strat_key is not None and strat_key not in df.columns:
+        print(f'{strat_key} not found in DataFrame')
+        strat_key = None
+    if strat_key is None or shuffle is False:
+        kf = KFold(n_splits=n_folds, shuffle=shuffle)
+        folds = kf.split(X=df if df is not None else tensor_data)
+    else:
+        kf = StratifiedKFold(n_splits=n_folds, shuffle=True)
+        folds = kf.split(X=df, y=df[strat_key])
 
     if tensor_as_sparse or tensor_target_as_sparse: import sparse
     for fold_idx, (_, fold) in enumerate(folds):


### PR DESCRIPTION
# Targeting v0.8.1

## Important changes

## Breaking

## Additions
- `df2foldfile` now has the option to not shuffle data into folds and instead split it into contiguous folds

## Removals

## Fixes

## Changes

## Depreciations

## Comments