### PR TITLE
fix: Use 'req@url' syntax to install from remote VCS

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx==2.2.0
--e git+https://github.com/GilesStrong/pytorch_sphinx_theme#egg=pytorch_sphinx_theme
--e git+https://github.com/hagenw/sphinxcontrib-katex.git#egg=sphinxcontrib.katex
+-e pytorch_sphinx_theme@git+https://github.com/GilesStrong/pytorch_sphinx_theme
+-e sphinxcontrib.katex@git+https://github.com/hagenw/sphinxcontrib-katex.git
 sphinx_autodoc_typehints==1.7.0
 sphinx_autodoc_annotation==1.0.post1
 -f https://download.pytorch.org/whl/cpu/torch_stable.html


### PR DESCRIPTION
Use 'req@url' syntax when using pip to install from a remote git repository over 'url#egg=req' to avoid the use of #egg= fragments with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. https://github.com/pypa/pip/pull/11617 for more details.